### PR TITLE
Add ThrottleDefinitions types

### DIFF
--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -227,7 +227,7 @@ enum ResponseCodeEnum {
   NODE_CAPACITY_NOT_SUFFICIENT_FOR_OPERATION = 217; // Given the network size in the address book, the node-level capacity for an operation would never be enough to accept a single request; usually means a bucket burstPeriod should be increased
   BUCKET_HAS_NO_THROTTLE_GROUPS = 218; // A bucket was defined without any throttle groups
   THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219; // A throttle group was assigned no opsPerSec
-  THROTTLE_MISSING_FOR_SUPPORTED_OPERATION = 220; // One or more supported HederaFunctionality values have no configured throttle 
+  SUCCESS_BUT_MISSING_EXPECTED_OPERATION = 220; // One or more supported HederaFunctionality values have no configured throttle 
   UNPARSEABLE_THROTTLE_DEFINITIONS = 221; // The new contents for the throttle definitions system file were not valid protobuf
   INVALID_THROTTLE_DEFINITIONS = 222; // The new contents for the throttle definitions system file were invalid, but a more specific error code could not be determined
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -222,4 +222,10 @@ enum ResponseCodeEnum {
   SCHEDULE_ALREADY_DELETED = 212; // A schedule being signed or deleted has already been deleted
   SCHEDULE_ALREADY_EXECUTED = 213; // A schedule being signed or deleted has already been executed
   MESSAGE_SIZE_TOO_LARGE = 214; // ConsensusSubmitMessage request's message size is larger than allowed.
+  OPERATION_REPEATED_IN_BUCKET_GROUPS = 215; // An operation may be only assigned to one opsPerSec group in a given bucket
+  BUCKET_CAPACITY_OVERFLOW = 216; // The capacity needed to satisfy all opsPerSec groups in a bucket overflowed a signed 8-byte integral type
+  NODE_CAPACITY_NOT_SUFFICIENT_FOR_OPERATION = 217; // Given the network size in the address book, the node-level capacity for an operation would never be enough to accept a single request; usually means a bucket burstPeriod should be increased
+  BUCKET_HAS_NO_THROTTLE_GROUPS = 218; // A bucket was defined without any throttle groups
+  THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219; // A throttle group was assigned no opsPerSec
+  THROTTLE_MISSING_FOR_SUPPORTED_OPERATION = 220; // One or more supported HederaFunctionality values have no configured throttle 
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -222,12 +222,12 @@ enum ResponseCodeEnum {
   SCHEDULE_ALREADY_DELETED = 212; // A schedule being signed or deleted has already been deleted
   SCHEDULE_ALREADY_EXECUTED = 213; // A schedule being signed or deleted has already been executed
   MESSAGE_SIZE_TOO_LARGE = 214; // ConsensusSubmitMessage request's message size is larger than allowed.
-  OPERATION_REPEATED_IN_BUCKET_GROUPS = 215; // An operation may be only assigned to one opsPerSec group in a given bucket
+  OPERATION_REPEATED_IN_BUCKET_GROUPS = 215; // An operation was assigned to more than one throttle group in a given bucket
   BUCKET_CAPACITY_OVERFLOW = 216; // The capacity needed to satisfy all opsPerSec groups in a bucket overflowed a signed 8-byte integral type
   NODE_CAPACITY_NOT_SUFFICIENT_FOR_OPERATION = 217; // Given the network size in the address book, the node-level capacity for an operation would never be enough to accept a single request; usually means a bucket burstPeriod should be increased
   BUCKET_HAS_NO_THROTTLE_GROUPS = 218; // A bucket was defined without any throttle groups
-  THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219; // A throttle group was assigned no opsPerSec
-  SUCCESS_BUT_MISSING_EXPECTED_OPERATION = 220; // One or more supported HederaFunctionality values have no configured throttle 
+  THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219; // A throttle group was granted zero opsPerSec
+  SUCCESS_BUT_MISSING_EXPECTED_OPERATION = 220; // The throttle definitions file was updated, but some supported operations were not assigned a bucket
   UNPARSEABLE_THROTTLE_DEFINITIONS = 221; // The new contents for the throttle definitions system file were not valid protobuf
-  INVALID_THROTTLE_DEFINITIONS = 222; // The new contents for the throttle definitions system file were invalid, but a more specific error code could not be determined
+  INVALID_THROTTLE_DEFINITIONS = 222; // The new throttle definitions system file were invalid, and no more specific error could be divined
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -228,4 +228,6 @@ enum ResponseCodeEnum {
   BUCKET_HAS_NO_THROTTLE_GROUPS = 218; // A bucket was defined without any throttle groups
   THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219; // A throttle group was assigned no opsPerSec
   THROTTLE_MISSING_FOR_SUPPORTED_OPERATION = 220; // One or more supported HederaFunctionality values have no configured throttle 
+  UNPARSEABLE_THROTTLE_DEFINITIONS = 221; // The new contents for the throttle definitions system file were not valid protobuf
+  INVALID_THROTTLE_DEFINITIONS = 222; // The new contents for the throttle definitions system file were invalid, but a more specific error code could not be determined
 }

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "BasicTypes.proto";
+
+message ThrottleGroup {
+  repeated HederaFunctionality operations = 1;
+  uint32 opsPerSec = 2;
+}
+
+message ThrottleBucket {
+  string name = 1;
+  uint32 burstPeriod = 2;
+  repeated ThrottleGroup throttleGroups = 3;
+}
+
+message ThrottleDefinitions {
+  repeated ThrottleBucket throttleBuckets = 1;
+}

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -27,17 +27,25 @@ option java_multiple_files = true;
 
 import "BasicTypes.proto";
 
+/* For details behind this throttling design, please see the <i>docs/throttle-design.md</i>
+document in the <a href="https://github.com/hashgraph/hedera-services">Hedera Services</a> repository. */
+
+/* A set of operations which should be collectively throttled at a given ops-per-second limit. */
 message ThrottleGroup {
-  repeated HederaFunctionality operations = 1;
-  uint32 opsPerSec = 2;
+  repeated HederaFunctionality operations = 1; // The operations to be throttled
+  uint32 opsPerSec = 2; // The rate to be allowed
 }
 
+/* A list of throttle groups that should compete for the same internal capacity bucket. */
 message ThrottleBucket {
-  string name = 1;
-  uint32 burstPeriod = 2;
-  repeated ThrottleGroup throttleGroups = 3;
+  string name = 1; // A name for this capacity bucket (primarily for use in logs)
+  uint32 burstPeriod = 2; // The number of seconds required for this bucket to drain completely when full
+  repeated ThrottleGroup throttleGroups = 3; // The throttle groups competing for this bucket's capacity
 }
 
+/* A list of throttle buckets which, simultaneously enforced, define the system's throttling policy. 
+(When an operation appears in more than one throttling bucket, all its buckets must have capacity
+or it will be throtted.) */
 message ThrottleDefinitions {
   repeated ThrottleBucket throttleBuckets = 1;
 }

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -36,16 +36,16 @@ message ThrottleGroup {
   uint64 milliOpsPerSec = 2; // The number of total operations per second across the entire network, multiplied by 1000. So, to choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
 }
 
-/* A list of throttle groups that should compete for the same internal capacity bucket. */
+/* A list of throttle groups that should all compete for the same internal bucket. */
 message ThrottleBucket {
-  string name = 1; // A name for this capacity bucket (primarily for use in logs)
+  string name = 1; // A name for this bucket (primarily for use in logs)
   uint64 burstPeriodMs = 2; // The number of milliseconds required for this bucket to drain completely when full. The product of this number and the least common multiple of the milliOpsPerSec values in this bucket must not exceed 9223372036.
-  repeated ThrottleGroup throttleGroups = 3; // The throttle groups competing for this bucket's capacity
+  repeated ThrottleGroup throttleGroups = 3; // The throttle groups competing for this bucket
 }
 
 /* A list of throttle buckets which, simultaneously enforced, define the system's throttling policy. 
 <ol>
-  <li> When an operation appears in more than one throttling bucket, all its buckets must have capacity
+  <li> When an operation appears in more than one throttling bucket, all its buckets must have room
 or it will be throttled.</li> 
   <li>An operation assigned to no buckets is always throttled.</li>
 </ol> 

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -46,7 +46,7 @@ message ThrottleBucket {
 /* A list of throttle buckets which, simultaneously enforced, define the system's throttling policy. 
 <ol>
   <li> When an operation appears in more than one throttling bucket, all its buckets must have capacity
-or it will be throtted.</li> 
+or it will be throttled.</li> 
   <li>An operation assigned to no buckets is always throttled.</li>
 </ol> 
 */

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -33,13 +33,13 @@ document in the <a href="https://github.com/hashgraph/hedera-services">Hedera Se
 /* A set of operations which should be collectively throttled at a given ops-per-second limit. */
 message ThrottleGroup {
   repeated HederaFunctionality operations = 1; // The operations to be throttled
-  uint32 opsPerSec = 2; // The rate to be allowed
+  uint64 milliOpsPerSec = 2; // The number of total operations per second across the entire network, multiplied by 1000. So, to choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
 }
 
 /* A list of throttle groups that should compete for the same internal capacity bucket. */
 message ThrottleBucket {
   string name = 1; // A name for this capacity bucket (primarily for use in logs)
-  uint32 burstPeriod = 2; // The number of seconds required for this bucket to drain completely when full
+  uint64 burstPeriodMs = 2; // The number of milliseconds required for this bucket to drain completely when full. The product of this number and the least common multiple of the milliOpsPerSec values in this bucket must not exceed 9223372036.
   repeated ThrottleGroup throttleGroups = 3; // The throttle groups competing for this bucket's capacity
 }
 

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -44,8 +44,12 @@ message ThrottleBucket {
 }
 
 /* A list of throttle buckets which, simultaneously enforced, define the system's throttling policy. 
-(When an operation appears in more than one throttling bucket, all its buckets must have capacity
-or it will be throtted.) */
+<ol>
+  <li> When an operation appears in more than one throttling bucket, all its buckets must have capacity
+or it will be throtted.</li> 
+  <li>An operation assigned to no buckets is always throttled.</li>
+</ol> 
+*/
 message ThrottleDefinitions {
   repeated ThrottleBucket throttleBuckets = 1;
 }

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -30,7 +30,7 @@ import "BasicTypes.proto";
 /* For details behind this throttling design, please see the <i>docs/throttle-design.md</i>
 document in the <a href="https://github.com/hashgraph/hedera-services">Hedera Services</a> repository. */
 
-/* A set of operations which should be collectively throttled at a given ops-per-second limit. */
+/* A set of operations which should be collectively throttled at a given milli-ops-per-second limit. */
 message ThrottleGroup {
   repeated HederaFunctionality operations = 1; // The operations to be throttled
   uint64 milliOpsPerSec = 2; // The number of total operations per second across the entire network, multiplied by 1000. So, to choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.


### PR DESCRIPTION
For a candidate set of throttles in JSON form (as used to update the throttle defs file `0.0.123` with YAHCLI), please see [here](https://github.com/hashgraph/hedera-services/blob/new-throttling-spec/hedera-node/src/main/resources/throttles.json). 