### PR TITLE
re-add deprecated fields to Transaction

### DIFF
--- a/services/Transaction.proto
+++ b/services/Transaction.proto
@@ -28,12 +28,19 @@ option java_multiple_files = true;
 
 import "Duration.proto";
 import "BasicTypes.proto";
+import "TransactionBody.proto";
 
 /* A single signed transaction, including all its signatures. The SignatureList will have a Signature for each Key in the transaction, either explicit or implicit, in the order that they appear in the transaction. For example, a CryptoTransfer will first have a Signature corresponding to the Key for the paying account, followed by a Signature corresponding to the Key for each account that is sending or receiving cryptocurrency in the transfer. Each Transaction should not have more than 50 levels. 
  * The SignatureList field is deprecated and succeeded by SignatureMap.
  */
 message Transaction {
-    bytes signedTransactionBytes = 5; // SignedTransaction serialized into bytes
-    bytes bodyBytes = 4 [deprecated = true]; // TransactionBody serialized into bytes, which needs to be signed
+    TransactionBody body = 1 [deprecated = true]; // the body of the transaction, which needs to be signed
+    
+    SignatureList sigs = 2 [deprecated = true]; // The signatures on the body, to authorize the transaction; deprecated and to be succeeded by SignatureMap field
+    
     SignatureMap sigMap = 3 [deprecated = true]; // The signatures on the body with the new format, to authorize the transaction
+    
+    bytes bodyBytes = 4 [deprecated = true]; // TransactionBody serialized into bytes, which needs to be signed
+
+    bytes signedTransactionBytes = 5; // SignedTransaction serialized into bytes
 }


### PR DESCRIPTION
previously deprecated fields are still needed to be able to historically parse valid transactions