### PR TITLE
Add full semver meta to SemanticVersion

### DIFF
--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -378,9 +378,11 @@ message NodeAddressBook {
 }
 
 message SemanticVersion {
-   int32 major = 1; // Increases with incompatible API changes
-   int32 minor = 2; // Increases with backwards-compatible new functionality
-   int32 patch = 3; // Increases with backwards-compatible bug fixes
+    int32 major = 1; // Increases with incompatible API changes
+    int32 minor = 2; // Increases with backwards-compatible new functionality
+    int32 patch = 3; // Increases with backwards-compatible bug fixes
+    string pre_release_version = 4; // A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (https://semver.org/#spec-item-9); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain 'alpha.1'
+    string build_metadata = 5; // Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version (https://semver.org/#spec-item-10); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain '21AF26D3'
 }
 
 message Setting {

--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -377,6 +377,9 @@ message NodeAddressBook {
     repeated NodeAddress nodeAddress = 1; // Metadata of all nodes in the network
 }
 
+/* Hedera follows semantic versioning (https://semver.org/) for both the HAPI protobufs and the Services software.
+This type allows the <tt>getVersionInfo</tt> query in the <tt>NetworkService</tt> to return the deployed versions
+of both protobufs and software on the node answering the query. */
 message SemanticVersion {
     int32 major = 1; // Increases with incompatible API changes
     int32 minor = 2; // Increases with backwards-compatible new functionality

--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -384,8 +384,8 @@ message SemanticVersion {
     int32 major = 1; // Increases with incompatible API changes
     int32 minor = 2; // Increases with backwards-compatible new functionality
     int32 patch = 3; // Increases with backwards-compatible bug fixes
-    string pre_release_version = 4; // A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (https://semver.org/#spec-item-9); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain 'alpha.1'
-    string build_metadata = 5; // Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version (https://semver.org/#spec-item-10); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain '21AF26D3'
+    string pre = 4; // A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (https://semver.org/#spec-item-9); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain 'alpha.1'
+    string build = 5; // Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version (https://semver.org/#spec-item-10); so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain '21AF26D3'
 }
 
 message Setting {


### PR DESCRIPTION
Allow the Services `getVersionInfo` query to [automatically return full info](https://github.com/hashgraph/hedera-services/pull/1339) on a deployed version via Maven property filtering.
- Add the `pre` and `build` fields from the [semver spec](https://semver.org/#spec-item-9) to our `SemanticVersion` proto type.