### PR TITLE
Add ACCOUNT_EXPIRED_AND_PENDING_REMOVAL response code

### DIFF
--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -230,4 +230,5 @@ enum ResponseCodeEnum {
   SUCCESS_BUT_MISSING_EXPECTED_OPERATION = 220; // The throttle definitions file was updated, but some supported operations were not assigned a bucket
   UNPARSEABLE_THROTTLE_DEFINITIONS = 221; // The new contents for the throttle definitions system file were not valid protobuf
   INVALID_THROTTLE_DEFINITIONS = 222; // The new throttle definitions system file were invalid, and no more specific error could be divined
+  ACCOUNT_EXPIRED_AND_PENDING_REMOVAL = 223; // The transaction references an account which has passed its expiration without renewal funds available, and currently remains in the ledger only because of the grace period given to expired entities
 }


### PR DESCRIPTION
**If auto-renew is enabled**, Services will return `ACCOUNT_EXPIRED_AND_PENDING_REMOVAL` upon any query or transaction that tries to use an account that has expired with a zero balance.

Such accounts are in a "grace period" and not allowed to participate in normal operations.