### PR TITLE
Add TokenFeeScheduleUpdate op to allow switch back to fee_schedule_key

### DIFF
--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -336,6 +336,7 @@ enum HederaFunctionality {
     TokenGetAccountNftInfo = 74; // Get Token Account Nft Information
     TokenGetNftInfo = 75; // Get Token Nft Information
     TokenGetNftInfos = 76; // Get Token Nft List Information
+    TokenFeeScheduleUpdate = 77; // Update a token's custom fee schedule, if permissible
 }
 
 /*

--- a/services/CustomFees.proto
+++ b/services/CustomFees.proto
@@ -22,6 +22,9 @@ package proto;
  * ‍
  */
 
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
 import "BasicTypes.proto";
 
 /* A fraction of the transferred units of a token to assess as a fee. The amount assessed

--- a/services/CustomFees.proto
+++ b/services/CustomFees.proto
@@ -57,9 +57,3 @@ message AssessedCustomFee {
   TokenID token_id = 2; // The denomination of the fee; taken as hbar if left unset
   AccountID fee_collector_account_id = 3; // The account to receive the assessed fee
 }
-
-/* The custom fees attached to a token; may be marked as mutable or immutable. */
-message CustomFees {
-  bool can_update_with_admin_key = 1; // Whether the fees can be updated with the token's admin key; once this is false, it can never be made true again
-  repeated CustomFee custom_fees = 2; // All the custom fees attached to the token
-}

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -249,8 +249,9 @@ enum ResponseCodeEnum {
   SENDER_DOES_NOT_OWN_NFT_SERIAL_NO = 237; // The transaction attempted to move an NFT serial number from an account other than its owner
   CUSTOM_FEE_NOT_FULLY_SPECIFIED = 238; // A custom fee schedule entry did not specify either a fixed or fractional fee
   CUSTOM_FEE_MUST_BE_POSITIVE = 239; // Only positive fees may be assessed at this time
-  CUSTOM_FEES_ARE_MARKED_IMMUTABLE = 240; // Once custom fees are marked as immutable, they can never be changed (or made mutable again)
+  TOKEN_HAS_NO_FEE_SCHEDULE_KEY = 240; // Fee schedule key is not set on token
   CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241; // A fractional custom fee exceeded the range of a 64-bit signed integer
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
   FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
+  CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
 }

--- a/services/TokenCreate.proto
+++ b/services/TokenCreate.proto
@@ -61,5 +61,6 @@ message TokenCreateTransactionBody {
     TokenType tokenType = 17; // IWA compatibility. Specifies the token type. Defaults to FUNGIBLE_COMMON
     TokenSupplyType supplyType = 18; // IWA compatibility. Specified the token supply type. Defaults to INFINITE
     int64 maxSupply = 19; // IWA Compatibility. Depends on TokenSupplyType. For tokens of type FUNGIBLE_COMMON - the maximum number of tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial numbers) that can be minted. This field can never be changed!
-    CustomFees custom_fees = 20; // Custom fees to be assessed during a CryptoTransfer that transfers units of this token
+    Key fee_schedule_key = 20; // The key which can change the token's custom fee schedule; must sign a TokenFeeScheduleUpdate transaction
+    repeated CustomFee custom_fees = 21; // The custom fees to be assessed during a CryptoTransfer that transfers units of this token
 }

--- a/services/TokenFeeScheduleUpdate.proto
+++ b/services/TokenFeeScheduleUpdate.proto
@@ -37,6 +37,6 @@ resolve to INVALID_SIGNATURE.
 If the custom_fees list is empty, clears the fee schedule or resolves to 
 CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES if the fee schedule was already empty. */
 message TokenFeeScheduleUpdateTransactionBody {
-    TokenID tokenId = 1; // The token whose fee schedule is to be updated
+    TokenID token_id = 1; // The token whose fee schedule is to be updated
     repeated CustomFee custom_fees = 2; // The new custom fees to be assessed during a CryptoTransfer that transfers units of this token
 }

--- a/services/TokenFeeScheduleUpdate.proto
+++ b/services/TokenFeeScheduleUpdate.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "BasicTypes.proto";
+import "CustomFees.proto";
+
+/* At consensus, updates a token type's fee schedule to the given list of custom fees. 
+
+If the target token type has no fee_schedule_key, resolves to TOKEN_HAS_NO_FEE_SCHEDULE_KEY.
+Otherwise this transaction must be signed to the fee_schedule_key, or the transaction will 
+resolve to INVALID_SIGNATURE.
+
+If the custom_fees list is empty, clears the fee schedule or resolves to 
+CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES if the fee schedule was already empty. */
+message TokenFeeScheduleUpdateTransactionBody {
+    TokenID tokenId = 1; // The token whose fee schedule is to be updated
+    repeated CustomFee custom_fees = 2; // The new custom fees to be assessed during a CryptoTransfer that transfers units of this token
+}

--- a/services/TokenGetInfo.proto
+++ b/services/TokenGetInfo.proto
@@ -61,7 +61,8 @@ message TokenInfo {
     TokenType tokenType = 19; // The token type
     TokenSupplyType supplyType = 20; // The token supply type
     int64 maxSupply = 21; // For tokens of type FUNGIBLE_COMMON - The Maximum number of fungible tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial numbers) that can be in circulation
-    CustomFees custom_fees = 22; // Custom fees to be assessed during a CryptoTransfer that transfers units of this token
+    Key fee_schedule_key = 22; // The key which can change the custom fee schedule of the token; if not set, the fee schedule is immutable
+    repeated CustomFee custom_fees = 23; // The custom fees to be assessed during a CryptoTransfer that transfers units of this token
 }
 
 /* Response when the client sends the node TokenGetInfoQuery */

--- a/services/TokenService.proto
+++ b/services/TokenService.proto
@@ -55,6 +55,8 @@ service TokenService {
     rpc associateTokens (Transaction) returns (TransactionResponse);
     // Dissociates tokens from an account
     rpc dissociateTokens (Transaction) returns (TransactionResponse);
+    // Updates the custom fee schedule on a token
+    rpc updateTokenFeeSchedule (Transaction) returns (TransactionResponse);
 
     // Retrieves the metadata of a token
     rpc getTokenInfo (Query) returns (Response);

--- a/services/TokenUpdate.proto
+++ b/services/TokenUpdate.proto
@@ -26,7 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 import "BasicTypes.proto";
-import "CustomFees.proto";
 import "Duration.proto";
 import "Timestamp.proto";
 import "google/protobuf/wrappers.proto";
@@ -54,5 +53,5 @@ message TokenUpdateTransactionBody {
     Duration autoRenewPeriod = 11; // The new interval at which the auto-renew account will be charged to extend the token's expiry.
     Timestamp expiry = 12; // The new expiry time of the token. Expiry can be updated even if admin key is not set. If the provided expiry is earlier than the current token expiry, transaction wil resolve to INVALID_EXPIRATION_TIME
     google.protobuf.StringValue memo = 13; // If set, the new memo to be associated with the token (UTF-8 encoding max 100 bytes)
-    CustomFees custom_fees = 14; // If set, the new custom fees to be assessed during a CryptoTransfer that transfers units of this token. If the can_update_with_admin_key field is already set to false for the token, this TokenUpdate will resolve to CUSTOM_FEES_ARE_MARKED_IMMUTABLE. If the can_update_with_admin_key field is set to false in this TokenUpdate, the new custom fees will take effect and stay immutable afterwards.
+    Key fee_schedule_key = 14; // If set, the new key to use to update the token's custom fee schedule; if the token does not currently have this key, transaction will resolve to TOKEN_HAS_NO_FEE_SCHEDULE_KEY
 }

--- a/services/TransactionBody.proto
+++ b/services/TransactionBody.proto
@@ -68,6 +68,7 @@ import "TokenBurn.proto";
 import "TokenWipeAccount.proto";
 import "TokenAssociate.proto";
 import "TokenDissociate.proto";
+import "TokenFeeScheduleUpdate.proto";
 
 import "ScheduleCreate.proto";
 import "ScheduleDelete.proto";
@@ -121,6 +122,7 @@ message TransactionBody {
     TokenWipeAccountTransactionBody tokenWipe = 39; // Wipes amount of tokens from an account
     TokenAssociateTransactionBody tokenAssociate = 40; // Associate tokens to an account
     TokenDissociateTransactionBody tokenDissociate = 41; // Dissociate tokens from an account
+    TokenFeeScheduleUpdateTransactionBody tokenFeeScheduleUpdate = 45; // Updates a token's custom fee schedule
 
     ScheduleCreateTransactionBody scheduleCreate = 42; // Creates a schedule in the network's action queue
     ScheduleDeleteTransactionBody scheduleDelete = 43; // Deletes a schedule from the network's action queue

--- a/services/TransactionBody.proto
+++ b/services/TransactionBody.proto
@@ -122,7 +122,7 @@ message TransactionBody {
     TokenWipeAccountTransactionBody tokenWipe = 39; // Wipes amount of tokens from an account
     TokenAssociateTransactionBody tokenAssociate = 40; // Associate tokens to an account
     TokenDissociateTransactionBody tokenDissociate = 41; // Dissociate tokens from an account
-    TokenFeeScheduleUpdateTransactionBody tokenFeeScheduleUpdate = 45; // Updates a token's custom fee schedule
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 45; // Updates a token's custom fee schedule
 
     ScheduleCreateTransactionBody scheduleCreate = 42; // Creates a schedule in the network's action queue
     ScheduleDeleteTransactionBody scheduleDelete = 43; // Deletes a schedule from the network's action queue


### PR DESCRIPTION
**Description**:
- Avoid a later breaking change by adding a new `TokenFeeScheduleUpdate` transaction, which allows the `custom_fee_key` to have use consistent with the other "role" keys for KYC, freezing/unfreezing, etc.

**List of changes**:
- Add `HederaFunctionality` enum value `TokenFeeScheduleUpdate`.
- Add `TransactionBody` choice `TokenFeeScheduleUpdateTransactionBody`.
- Remove `CustomFees` wrapper and its use in `TokenUpdate`.
- Leave `repeated CustomFee custom_fees` in `TokenCreate` at top-level.
- Restore the `fee_schedule_key` to `TokenCreate`, `TokenUpdate`, and `TokenGetInfo`.