### PR TITLE
Add more responseCodes

### DIFF
--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -254,4 +254,6 @@ enum ResponseCodeEnum {
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
   FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
   CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
+  CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // If a fee schedule denomination is a token, it must be a Fungible Token
+  CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // A Non Fungible Token cannot have a fraction fee in its FeeSchedule
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -254,7 +254,7 @@ enum ResponseCodeEnum {
   INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
   FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
   CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
-  CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // If a fee schedule denomination is a token, it must be a Fungible Token
-  CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // A Non Fungible Token cannot have a fraction fee in its FeeSchedule
-  INVALID_CUSTOM_FEE_SCHEDULE_KEY = 247; // The provided custom fee schedule key was invalid.
+  CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // Only tokens of type FUNGIBLE_COMMON can be used to as fee schedule denominations
+  CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // Only tokens of type FUNGIBLE_COMMON can have fractional fees
+  INVALID_CUSTOM_FEE_SCHEDULE_KEY = 247; // The provided custom fee schedule key was invalid
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -256,4 +256,5 @@ enum ResponseCodeEnum {
   CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
   CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // If a fee schedule denomination is a token, it must be a Fungible Token
   CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // A Non Fungible Token cannot have a fraction fee in its FeeSchedule
+  INVALID_FEE_SCHEDULE_KEY = 247; // The provided fee schedule key was invalid.
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -256,5 +256,5 @@ enum ResponseCodeEnum {
   CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
   CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // If a fee schedule denomination is a token, it must be a Fungible Token
   CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // A Non Fungible Token cannot have a fraction fee in its FeeSchedule
-  INVALID_FEE_SCHEDULE_KEY = 247; // The provided fee schedule key was invalid.
+  INVALID_CUSTOM_FEE_SCHEDULE_KEY = 247; // The provided custom fee schedule key was invalid.
 }


### PR DESCRIPTION
Added response codes for if we a denominating token type is a NFT and one for when and NFT has a fractional fee in its feeSchedule

Signed-off-by: anighanta <anirudh.ghanta@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #48 
Related to https://github.com/hashgraph/hedera-services/issues/1722
