### PR TITLE
Update response code

### DIFF
--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -85,7 +85,7 @@ message TransferList {
     repeated AccountAmount accountAmounts = 1; // Multiple list of AccountAmount pairs, each of which has an account and an amount to transfer into it (positive) or out of it (negative)
 }
 
-/* A sender account, a receiver account, and the serial number of an NFT of a Token with NON_FUNGIBLE_UNIQUE type. */
+/* A sender account, a receiver account, and the serial number of an NFT of a Token with NON_FUNGIBLE_UNIQUE type. When minting NFTs the sender will be the default AccountID instance (0.0.0) and when burning NFTs, the receiver will be the default AccountID instance. */
 message NftTransfer {
     AccountID senderAccountID = 1; // The accountID of the sender
     AccountID receiverAccountID = 2; // The accountID of the receiver
@@ -97,6 +97,12 @@ message TokenTransferList {
     TokenID token = 1; // The ID of the token
     repeated AccountAmount transfers = 2; // Applicable to tokens of type FUNGIBLE_COMMON. Multiple list of AccountAmounts, each of which has an account and amount
     repeated NftTransfer nftTransfers = 3; // Applicable to tokens of type NON_FUNGIBLE_UNIQUE. Multiple list of NftTransfers, each of which has a sender and receiver account, including the serial number of the NFT
+}
+
+/* A rational number, used to set the amount of a value transfer to collect as a custom fee */
+message Fraction {
+    int64 numerator = 1; // The rational's numerator
+    int64 denominator = 2; // The rational's denominator; a zero value will result in FRACTION_DIVIDES_BY_ZERO
 }
 
 /* Unique identifier for a topic (used by the consensus service) */
@@ -138,15 +144,23 @@ enum TokenType {
     NON_FUNGIBLE_UNIQUE = 1;
 }
 
-
 /**
- * Possible FeeData Object SubTypes. Supplementary to the main HederaFunctionality Type.
- * When not explicitly specified, DEFAULT is used.
+ * Allows a set of resource prices to be scoped to a certain type of a HAPI operation. 
+ * 
+ * For example, the resource prices for a TokenMint operation are different between
+ * minting fungible and non-fungible tokens. This enum allows us to "mark" a set of 
+ * prices as applying to one or the other.
+ * 
+ * Similarly, the resource prices for a basic TokenCreate without a custom fee schedule 
+ * yield a total price of $1. The resource prices for a TokenCreate with a custom fee 
+ * schedule are different and yield a total base price of $2.
  */
 enum SubType {
-    DEFAULT = 0;
-    TOKEN_FUNGIBLE_COMMON = 1;
-    TOKEN_NON_FUNGIBLE_UNIQUE = 2;
+    DEFAULT = 0; // The resource prices have no special scope 
+    TOKEN_FUNGIBLE_COMMON = 1; // The resource prices are scoped to an operation on a fungible common token
+    TOKEN_NON_FUNGIBLE_UNIQUE = 2; // The resource prices are scoped to an operation on a non-fungible unique token
+    TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES = 3; // The resource prices are scoped to an operation on a fungible common token with a custom fee schedule
+    TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES = 4; // The resource prices are scoped to an operation on a non-fungible unique token with a custom fee schedule
 }
 
 /**
@@ -328,9 +342,10 @@ enum HederaFunctionality {
     ScheduleDelete = 71; // Delete Scheduled Transaction
     ScheduleSign = 72; // Sign Scheduled Transaction
     ScheduleGetInfo = 73; // Get Scheduled Transaction Information
-    TokenGetAccountNftInfo = 74; // Get Token Account Nft Information
+    TokenGetAccountNftInfos = 74; // Get Token Account Nft Information
     TokenGetNftInfo = 75; // Get Token Nft Information
     TokenGetNftInfos = 76; // Get Token Nft List Information
+    TokenFeeScheduleUpdate = 77; // Update a token's custom fee schedule, if permissible
 }
 
 /*

--- a/services/CryptoTransfer.proto
+++ b/services/CryptoTransfer.proto
@@ -27,10 +27,10 @@ option java_multiple_files = true;
 
 import "BasicTypes.proto";
 
-/* Transfer cryptocurrency from some accounts to other accounts. The accounts list can contain up to 10 accounts. The amounts list must be the same length as the accounts list. Each negative amount is withdrawn from the corresponding account (a sender), and each positive one is added to the corresponding account (a receiver). The amounts list must sum to zero. Each amount is a number of tinyBars (there are 100,000,000 tinyBars in one Hbar).
+/* Transfers cryptocurrency among two or more accounts by making the desired adjustments to their balances. Each transfer list can specify up to 10 adjustments. Each negative amount is withdrawn from the corresponding account (a sender), and each positive one is added to the corresponding account (a receiver). The amounts list must sum to zero. Each amount is a number of tinybars (there are 100,000,000 tinybars in one hbar).
 If any sender account fails to have sufficient hbars, then the entire transaction fails, and none of those transfers occur, though the transaction fee is still charged. This transaction must be signed by the keys for all the sending accounts, and for any receiving accounts that have receiverSigRequired == true. The signatures are in the same order as the accounts, skipping those accounts that don't need a signature.
 */
 message CryptoTransferTransactionBody {
-    TransferList transfers = 1;
-    repeated TokenTransferList tokenTransfers = 2;
+    TransferList transfers = 1;  // The desired hbar balance adjustments
+    repeated TokenTransferList tokenTransfers = 2; // The desired token unit balance adjustments; if any custom fees are assessed, the ledger will try to deduct them from the payer of this CryptoTransfer, resolving the transaction to INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE if this is not possible
 }

--- a/services/CustomFees.proto
+++ b/services/CustomFees.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "BasicTypes.proto";
+
+/* A fraction of the transferred units of a token to assess as a fee. The amount assessed
+will never be less than the given minimum_amount, and never greater than the given maximum_amount. 
+The denomination is always units of the token to which this fractional fee is attached. */
+message FractionalFee {
+  Fraction fractional_amount = 1; // The fraction of the transferred units to assess as a fee
+  int64 minimum_amount = 2; // The minimum amount to assess
+  int64 maximum_amount = 3; // The maximum amount to assess (zero implies no maximum)
+}
+
+/* A fixed number of units (hbar or token) to assess as a fee during a CryptoTransfer 
+that transfers units of the token to which this fixed fee is attached. */
+message FixedFee {
+  int64 amount = 1; // The number of units to assess as a fee
+  TokenID denominating_token_id = 2; // The denomination of the fee; taken as hbar if left unset and, in a TokenCreate, taken as the id of the newly created token if set to the sentinel value of 0.0.0
+}
+
+/* A transfer fee to assess during a CryptoTransfer that transfers units of the token 
+to which the fee is attached. A custom fee may be either fixed or fractional, and must specify
+a fee collector account to receive the assessed fees. Only positive fees may be assessed. */
+message CustomFee {
+  oneof fee {
+    FixedFee fixed_fee = 1; // Fixed fee to be charged
+    FractionalFee fractional_fee = 2; // Fractional fee to be charged
+  }
+  AccountID fee_collector_account_id = 3; // The account to receive the custom fee
+}
+
+/* A custom transfer fee that was assessed during handling of a CryptoTransfer. */
+message AssessedCustomFee {
+  int64 amount = 1; // The number of units assessed for the fee
+  TokenID token_id = 2; // The denomination of the fee; taken as hbar if left unset
+  AccountID fee_collector_account_id = 3; // The account to receive the assessed fee
+}

--- a/services/Query.proto
+++ b/services/Query.proto
@@ -52,7 +52,7 @@ import "NetworkGetVersionInfo.proto";
 import "TokenGetInfo.proto";
 import "ScheduleGetInfo.proto";
 
-import "TokenGetAccountNftInfo.proto";
+import "TokenGetAccountNftInfos.proto";
 import "TokenGetNftInfo.proto";
 import "TokenGetNftInfos.proto";
 
@@ -86,7 +86,7 @@ message Query {
 
         ScheduleGetInfoQuery scheduleGetInfo = 53; // Get all information about a scheduled entity
 
-        TokenGetAccountNftInfoQuery tokenGetAccountNftInfo = 54; // Get a list of NFTs associated with the account
+        TokenGetAccountNftInfosQuery tokenGetAccountNftInfos = 54; // Get a list of NFTs associated with the account
         TokenGetNftInfoQuery tokenGetNftInfo = 55; // Get all information about a NFT
         TokenGetNftInfosQuery tokenGetNftInfos = 56; // Get a list of NFTs for the token
     }

--- a/services/Response.proto
+++ b/services/Response.proto
@@ -50,7 +50,7 @@ import "ConsensusGetTopicInfo.proto";
 
 import "NetworkGetVersionInfo.proto";
 
-import "TokenGetAccountNftInfo.proto";
+import "TokenGetAccountNftInfos.proto";
 import "TokenGetInfo.proto";
 import "TokenGetNftInfo.proto";
 import "TokenGetNftInfos.proto";
@@ -90,7 +90,7 @@ message Response {
 
         ScheduleGetInfoResponse scheduleGetInfo = 153; // Get all information about a schedule entity
 
-        TokenGetAccountNftInfoResponse tokenGetAccountNftInfo = 154; // A list of the NFTs associated with the account
+        TokenGetAccountNftInfosResponse tokenGetAccountNftInfos = 154; // A list of the NFTs associated with the account
         TokenGetNftInfoResponse tokenGetNftInfo = 155; // All information about an NFT
         TokenGetNftInfosResponse tokenGetNftInfos = 156; // A list of the NFTs for the token
     }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -158,6 +158,8 @@ enum ResponseCodeEnum {
   EXPIRATION_REDUCTION_NOT_ALLOWED = 110; // The expiration date/time on a smart contract may not be reduced
   MAX_GAS_LIMIT_EXCEEDED = 111; //Gas exceeded currently allowable gas limit per transaction
   MAX_FILE_SIZE_EXCEEDED = 112; // File size exceeded the currently allowable limit
+  RECEIVER_SIG_REQUIRED = 113; // When a valid signature is not provided for operations on account with receiverSigRequired=true
+
   INVALID_TOPIC_ID = 150; // The Topic ID specified is not in the system.
   INVALID_ADMIN_KEY = 155; // A provided admin key was invalid.
   INVALID_SUBMIT_KEY = 156; // A provided submit key was invalid.
@@ -236,5 +238,34 @@ enum ResponseCodeEnum {
   INVALID_NFT_ID = 226; // Invalid nft id
   METADATA_TOO_LONG = 227; // Nft metadata is too long
   BATCH_SIZE_LIMIT_EXCEEDED = 228; // Repeated operations count exceeds the limit
-  QUERY_RANGE_LIMIT_EXCEEDED = 229; // The range of data to be gathered exceeds the limit
+  INVALID_QUERY_RANGE = 229; // The range of data to be gathered is out of the set boundaries
+  FRACTION_DIVIDES_BY_ZERO = 230; // A custom fractional fee set a denominator of zero
+  INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE = 231; // The transaction payer could not afford a custom fee
+  CUSTOM_FEES_LIST_TOO_LONG = 232; // More than 10 custom fees were specified
+  INVALID_CUSTOM_FEE_COLLECTOR = 233; // Any of the feeCollector accounts for customFees is invalid
+  INVALID_TOKEN_ID_IN_CUSTOM_FEES = 234; // Any of the token Ids in customFees is invalid
+  TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR = 235; // Any of the token Ids in customFees are not associated to feeCollector
+  TOKEN_MAX_SUPPLY_REACHED = 236; // A token cannot have more units minted due to its configured supply ceiling
+  SENDER_DOES_NOT_OWN_NFT_SERIAL_NO = 237; // The transaction attempted to move an NFT serial number from an account other than its owner
+  CUSTOM_FEE_NOT_FULLY_SPECIFIED = 238; // A custom fee schedule entry did not specify either a fixed or fractional fee
+  CUSTOM_FEE_MUST_BE_POSITIVE = 239; // Only positive fees may be assessed at this time
+  TOKEN_HAS_NO_FEE_SCHEDULE_KEY = 240; // Fee schedule key is not set on token
+  CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241; // A fractional custom fee exceeded the range of a 64-bit signed integer
+  INVALID_CUSTOM_FRACTIONAL_FEES_SUM = 242; // The sum of all custom fractional fees must be strictly less than 1
+  FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243; // Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
+  CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244; // A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
+  CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245; // Only tokens of type FUNGIBLE_COMMON can be used to as fee schedule denominations
+  CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246; // Only tokens of type FUNGIBLE_COMMON can have fractional fees
+  INVALID_CUSTOM_FEE_SCHEDULE_KEY = 247; // The provided custom fee schedule key was invalid
+  INVALID_TOKEN_MINT_METADATA = 248; // The requested token mint metadata was invalid
+  INVALID_TOKEN_BURN_METADATA = 249; // The requested token burn metadata was invalid
+  CURRENT_TREASURY_STILL_OWNS_NFTS = 250; // The treasury for a unique token cannot be changed until it owns no NFTs
+  ACCOUNT_STILL_OWNS_NFTS = 251; // An account cannot be dissociated from a unique token if it owns NFTs for the token
+  TREASURY_MUST_OWN_BURNED_NFT = 252; // A NFT can only be burned when owned by the unique token's treasury
+  ACCOUNT_DOES_NOT_OWN_WIPED_NFT = 253; // An account did not own the NFT to be wiped
+  ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 254; // An AccountAmount token transfers list referenced a token type other than FUNGIBLE_COMMON
+  MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED = 255; // All the NFTs allowed in the current price regime have already been minted
+  PAYER_ACCOUNT_DELETED = 256; // The payer account has been marked as deleted
+  CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH = 257; // The reference chain of custom fees for a transferred token exceeded the maximum length of 2
+  CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS = 258; // More than 20 balance adjustments were to satisfy a CryptoTransfer and its implied custom fee payments
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -240,7 +240,7 @@ enum ResponseCodeEnum {
   BATCH_SIZE_LIMIT_EXCEEDED = 228; // Repeated operations count exceeds the limit
   INVALID_QUERY_RANGE = 229; // The range of data to be gathered is out of the set boundaries
   FRACTION_DIVIDES_BY_ZERO = 230; // A custom fractional fee set a denominator of zero
-  INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE = 231; // The transaction payer could not afford a custom fee
+  INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE = 231; // The sending account in the token transfer transaction could not afford a custom fee
   CUSTOM_FEES_LIST_TOO_LONG = 232; // More than 10 custom fees were specified
   INVALID_CUSTOM_FEE_COLLECTOR = 233; // Any of the feeCollector accounts for customFees is invalid
   INVALID_TOKEN_ID_IN_CUSTOM_FEES = 234; // Any of the token Ids in customFees is invalid

--- a/services/TokenBurn.proto
+++ b/services/TokenBurn.proto
@@ -32,7 +32,13 @@ Burns tokens from the Token's treasury Account. If no Supply Key is defined, the
 The operation decreases the Total Supply of the Token. Total supply cannot go below zero.
 The amount provided must be in the lowest denomination possible. Example:
 Token A has 2 decimals. In order to burn 100 tokens, one must provide amount of 10000. In order to burn 100.55 tokens, one must provide amount of 10055.
- */
+For non fungible tokens the transaction body accepts serialNumbers list of integers as a parameter.
+
+If neither the amount nor the serialNumbers get filled, a INVALID_TOKEN_BURN_AMOUNT response code will be returned.
+If both amount and serialNumbers get filled, a INVALID_TRANSACTION_BODY response code will be returned.
+If the serialNumbers' list count is greater than the batch size limit global dynamic property, a BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
+If the serialNumbers list contains a non-positive integer as a serial number, a INVALID_NFT_ID response code will be returned.
+*/
 message TokenBurnTransactionBody {
     TokenID token = 1; // The token for which to burn tokens. If token does not exist, transaction results in INVALID_TOKEN_ID
     uint64 amount = 2; // Applicable to tokens of type FUNGIBLE_COMMON. The amount to burn from the Treasury Account. Amount must be a positive non-zero number, not bigger than the token balance of the treasury account (0; balance], represented in the lowest denomination.

--- a/services/TokenCreate.proto
+++ b/services/TokenCreate.proto
@@ -27,19 +27,32 @@ option java_multiple_files = true;
 
 import "Duration.proto";
 import "BasicTypes.proto";
+import "CustomFees.proto";
 import "Timestamp.proto";
 
 /*
 Create a new token. After the token is created, the Token ID for it is in the receipt.
 The specified Treasury Account is receiving the initial supply of tokens as-well as the tokens from the Token Mint operation once executed. The balance of the treasury account is decreased when the Token Burn operation is executed.
 
-The <tt>initialSupply</tt> is the initial supply of the smallest parts of a token (like a tinybar, not an hbar). These are the smallest units of the token which may be transferred. 
+The <tt>initialSupply</tt> is the initial supply of the smallest parts of a token (like a tinybar, not an hbar). These are the smallest units of the token which may be transferred.
 
 The supply can change over time. If the total supply at some moment is <i>S</i> parts of tokens, and the token is using <i>D</i> decimals, then <i>S</i> must be less than or equal to 2<sup>63</sup>-1, which is 9,223,372,036,854,775,807. The number of whole tokens (not parts) will be <i>S / 10<sup>D</sup></i>.
 
 If decimals is 8 or 11, then the number of whole tokens can be at most a few billions or millions, respectively. For example, it could match Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals). It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
 
 Note that a created token is <i>immutable</i> if the <tt>adminKey</tt> is omitted. No property of an immutable token can ever change, with the sole exception of its expiry. Anyone can pay to extend the expiry time of an immutable token.
+
+A token can be either <i>FUNGIBLE_COMMON</i> or <i>NON_FUNGIBLE_UNIQUE</i>, based on its <i>TokenType</i>. If it has been omitted, <i>FUNGIBLE_COMMON</i> type is used.
+
+A token can have either <i>INFINITE</i> or <i>FINITE</i> supply type, based on its <i>TokenType</i>. If it has been omitted, <i>INFINITE</i> type is used.
+
+If a <i>FUNGIBLE</i> TokenType is used, <i>initialSupply</i> should explicitly be set to a non-negative. If not, the transaction will resolve to INVALID_TOKEN_INITIAL_SUPPLY.
+
+If a <i>NON_FUNGIBLE_UNIQUE</i> TokenType is used, <i>initialSupply</i> should explicitly be set to 0. If not, the transaction will resolve to INVALID_TOKEN_INITIAL_SUPPLY.
+
+If an <i>INFINITE</i> TokenSupplyType is used, <i>maxSupply</i> should explicitly be set to 0. If it is not 0, the transaction will resolve to INVALID_TOKEN_MAX_SUPPLY.
+
+If a <i>FINITE</i> TokenSupplyType is used, <i>maxSupply</i> should be explicitly set to a non-negative value. If it is not, the transaction will resolve to INVALID_TOKEN_MAX_SUPPLY.
  */
 message TokenCreateTransactionBody {
     string name = 1; // The publicly visible name of the token, limited to a UTF-8 encoding of length <tt>tokens.maxSymbolUtf8Bytes</tt>.
@@ -60,4 +73,6 @@ message TokenCreateTransactionBody {
     TokenType tokenType = 17; // IWA compatibility. Specifies the token type. Defaults to FUNGIBLE_COMMON
     TokenSupplyType supplyType = 18; // IWA compatibility. Specified the token supply type. Defaults to INFINITE
     int64 maxSupply = 19; // IWA Compatibility. Depends on TokenSupplyType. For tokens of type FUNGIBLE_COMMON - the maximum number of tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial numbers) that can be minted. This field can never be changed!
+    Key fee_schedule_key = 20; // The key which can change the token's custom fee schedule; must sign a TokenFeeScheduleUpdate transaction
+    repeated CustomFee custom_fees = 21; // The custom fees to be assessed during a CryptoTransfer that transfers units of this token
 }

--- a/services/TokenDissociate.proto
+++ b/services/TokenDissociate.proto
@@ -33,7 +33,9 @@ import "BasicTypes.proto";
  If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
  If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
  If an association between the provided account and any of the tokens does not exist, the transaction will resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
- If the provided account has a nonzero balance with any of the provided tokens, the transaction will resolve to TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES.
+ If a token has not been deleted and has not expired, and the user has a nonzero balance, the transaction will resolve to TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES.
+ If a <b>fungible token</b> has expired, the user can disassociate even if their token balance is not zero.
+ If a <b>non fungible token</b> has expired, the user can <b>not</b> disassociate if their token balance is not zero. The transaction will resolve to TRANSACTION_REQUIRED_ZERO_TOKEN_BALANCES.
  On success, associations between the provided account and tokens are removed.
  */
 message TokenDissociateTransactionBody {

--- a/services/TokenFeeScheduleUpdate.proto
+++ b/services/TokenFeeScheduleUpdate.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "BasicTypes.proto";
+import "CustomFees.proto";
+
+/* At consensus, updates a token type's fee schedule to the given list of custom fees. 
+
+If the target token type has no fee_schedule_key, resolves to TOKEN_HAS_NO_FEE_SCHEDULE_KEY.
+Otherwise this transaction must be signed to the fee_schedule_key, or the transaction will 
+resolve to INVALID_SIGNATURE.
+
+If the custom_fees list is empty, clears the fee schedule or resolves to 
+CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES if the fee schedule was already empty. */
+message TokenFeeScheduleUpdateTransactionBody {
+    TokenID token_id = 1; // The token whose fee schedule is to be updated
+    repeated CustomFee custom_fees = 2; // The new custom fees to be assessed during a CryptoTransfer that transfers units of this token
+}

--- a/services/TokenGetAccountNftInfos.proto
+++ b/services/TokenGetAccountNftInfos.proto
@@ -32,15 +32,27 @@ import "ResponseHeader.proto";
 
 /* Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on NFTs N through M owned by the specified accountId.
  * Example: If Account A owns 5 NFTs (might be of different Token Entity), having start=0 and end=5 will return all of the NFTs
+  *
+ * INVALID_QUERY_RANGE response code will be returned if:
+ * 1) Start > End
+ * 2) Start and End indices are non-positive
+ * 3) Start and End indices are out of boundaries for the retrieved nft list
+ * 4) The range between Start and End is bigger than the global dynamic property for maximum query range
+ *
+ * NOT_SUPPORTED response code will be returned if the queried token is of type FUNGIBLE_COMMON
+ *
+ * INVALID_ACCOUNT_ID response code will be returned if the queried account does not exist
+ *
+ * ACCOUNT_DELETED response code will be returned if the queried account has been deleted
  */
-message TokenGetAccountNftInfoQuery {
+message TokenGetAccountNftInfosQuery {
     QueryHeader header = 1; // Standard info sent from client to node, including the signed payment, and what kind of response is requested (cost, state proof, both, or neither).
     AccountID accountID = 2; // The Account for which information is requested
     int64 start = 3; // Specifies the start index (inclusive) of the range of NFTs to query for. Value must be in the range [0; ownedNFTs-1]
     int64 end = 4; // Specifies the end index (exclusive) of the range of NFTs to query for. Value must be in the range (start; ownedNFTs]
 }
 
-message TokenGetAccountNftInfoResponse {
+message TokenGetAccountNftInfosResponse {
     ResponseHeader header = 1; // Standard response from node to client, including the requested fields: cost, or state proof, or both, or neither
     repeated TokenNftInfo nfts = 2; // List of NFTs associated to the account
 }

--- a/services/TokenGetInfo.proto
+++ b/services/TokenGetInfo.proto
@@ -26,6 +26,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 import "BasicTypes.proto";
+import "CustomFees.proto";
 import "QueryHeader.proto";
 import "ResponseHeader.proto";
 import "Timestamp.proto";
@@ -60,6 +61,8 @@ message TokenInfo {
     TokenType tokenType = 19; // The token type
     TokenSupplyType supplyType = 20; // The token supply type
     int64 maxSupply = 21; // For tokens of type FUNGIBLE_COMMON - The Maximum number of fungible tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial numbers) that can be in circulation
+    Key fee_schedule_key = 22; // The key which can change the custom fee schedule of the token; if not set, the fee schedule is immutable
+    repeated CustomFee custom_fees = 23; // The custom fees to be assessed during a CryptoTransfer that transfers units of this token
 }
 
 /* Response when the client sends the node TokenGetInfoQuery */

--- a/services/TokenGetNftInfos.proto
+++ b/services/TokenGetNftInfos.proto
@@ -32,6 +32,16 @@ import "ResponseHeader.proto";
 
 /* Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on NFTs N through M on the list of NFTs associated with a given NON_FUNGIBLE_UNIQUE Token.
  * Example: If there are 10 NFTs issued, having start=0 and end=5 will query for the first 5 NFTs. Querying +all 10 NFTs will require start=0 and end=10
+ *
+ * INVALID_QUERY_RANGE response code will be returned if:
+ * 1) Start > End
+ * 2) Start and End indices are non-positive
+ * 3) Start and End indices are out of boundaries for the retrieved nft list
+ * 4) The range between Start and End is bigger than the global dynamic property for maximum query range
+ *
+ * NOT_SUPPORTED response code will be returned if the queried token is of type FUNGIBLE_COMMON
+ *
+ * INVALID_TOKEN_ID response code will be returned if the queried token does not exist
  */
 message TokenGetNftInfosQuery {
     QueryHeader header = 1; // Standard info sent from client to node, including the signed payment, and what kind of response is requested (cost, state proof, both, or neither).

--- a/services/TokenMint.proto
+++ b/services/TokenMint.proto
@@ -32,6 +32,10 @@ Mints tokens to the Token's treasury Account. If no Supply Key is defined, the t
 The operation increases the Total Supply of the Token. The maximum total supply a token can have is 2^63-1.
 The amount provided must be in the lowest denomination possible. Example:
 Token A has 2 decimals. In order to mint 100 tokens, one must provide amount of 10000. In order to mint 100.55 tokens, one must provide amount of 10055.
+If both amount and metadata list get filled, a INVALID_TRANSACTION_BODY response code will be returned.
+If the metadata list contains metadata which is too large, a METADATA_TOO_LONG response code will be returned.
+If neither the amount nor the metadata list get filled, a INVALID_TOKEN_MINT_AMOUNT response code will be returned.
+If the metadata list count is greater than the batch size limit global dynamic property, a BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
  */
 message TokenMintTransactionBody {
     TokenID token = 1; // The token for which to mint tokens. If token does not exist, transaction results in INVALID_TOKEN_ID

--- a/services/TokenService.proto
+++ b/services/TokenService.proto
@@ -55,11 +55,13 @@ service TokenService {
     rpc associateTokens (Transaction) returns (TransactionResponse);
     // Dissociates tokens from an account
     rpc dissociateTokens (Transaction) returns (TransactionResponse);
+    // Updates the custom fee schedule on a token
+    rpc updateTokenFeeSchedule (Transaction) returns (TransactionResponse);
 
     // Retrieves the metadata of a token
     rpc getTokenInfo (Query) returns (Response);
     // Gets info on NFTs N through M on the list of NFTs associated with a given account
-    rpc getAccountNftInfo (Query) returns (Response);
+    rpc getAccountNftInfos (Query) returns (Response);
     // Retrieves the metadata of an NFT by TokenID and serial number
     rpc getTokenNftInfo (Query) returns (Response);
     // Gets info on NFTs N through M on the list of NFTs associated with a given Token of type NON_FUNGIBLE

--- a/services/TokenUpdate.proto
+++ b/services/TokenUpdate.proto
@@ -38,7 +38,11 @@ If no value is given for a field, that field is left unchanged. For an immutable
 1. Whether or not a token has an admin key, its expiry can be extended with only the transaction payer's signature.
 2. Updating any other field of a mutable token requires the admin key's signature.
 3. If a new admin key is set, this new key must sign <b>unless</b> it is exactly an empty <tt>KeyList</tt>. This special sentinel key removes the existing admin key and causes the token to become immutable. (Other <tt>Key</tt> structures without a constituent <tt>Ed25519</tt> key will be rejected with <tt>INVALID_ADMIN_KEY</tt>.)
-4. If a new treasury is set, the new treasury account's key must sign the transaction. */
+4. If a new treasury is set, the new treasury account's key must sign the transaction.
+
+--- Nft Requirements ---
+1. If a non fungible token has a positive treasury balance, the operation will abort with CURRENT_TREASURY_STILL_OWNS_NFTS.
+*/
 message TokenUpdateTransactionBody {
     TokenID token = 1; // The Token to be updated
     string symbol = 2; // The new publicly visible Token symbol, limited to a UTF-8 encoding of length <tt>tokens.maxTokenNameUtf8Bytes</tt>.
@@ -53,4 +57,5 @@ message TokenUpdateTransactionBody {
     Duration autoRenewPeriod = 11; // The new interval at which the auto-renew account will be charged to extend the token's expiry.
     Timestamp expiry = 12; // The new expiry time of the token. Expiry can be updated even if admin key is not set. If the provided expiry is earlier than the current token expiry, transaction wil resolve to INVALID_EXPIRATION_TIME
     google.protobuf.StringValue memo = 13; // If set, the new memo to be associated with the token (UTF-8 encoding max 100 bytes)
+    Key fee_schedule_key = 14; // If set, the new key to use to update the token's custom fee schedule; if the token does not currently have this key, transaction will resolve to TOKEN_HAS_NO_FEE_SCHEDULE_KEY
 }

--- a/services/TokenWipeAccount.proto
+++ b/services/TokenWipeAccount.proto
@@ -37,6 +37,11 @@ import "BasicTypes.proto";
  If the provided account is the Token's Treasury Account, transaction results in CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT
  On success, tokens are removed from the account and the total supply of the token is decreased by the wiped amount.
 
+ If both amount and serialNumbers get filled, a INVALID_TRANSACTION_BODY response code will be returned.
+ If neither the amount nor the serialNumbers get filled, a INVALID_WIPING_AMOUNT response code will be returned.
+ If the serialNumbers list contains a non-positive integer as a serial number, a INVALID_NFT_ID response code will be returned.
+ If the serialNumbers' list count is greater than the batch size limit global dynamic property, a BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
+
  The amount provided is in the lowest denomination possible. Example:
  Token A has 2 decimals. In order to wipe 100 tokens from account, one must provide amount of 10000. In order to wipe 100.55 tokens, one must provide amount of 10055.
  */

--- a/services/Transaction.proto
+++ b/services/Transaction.proto
@@ -28,12 +28,19 @@ option java_multiple_files = true;
 
 import "Duration.proto";
 import "BasicTypes.proto";
+import "TransactionBody.proto";
 
 /* A single signed transaction, including all its signatures. The SignatureList will have a Signature for each Key in the transaction, either explicit or implicit, in the order that they appear in the transaction. For example, a CryptoTransfer will first have a Signature corresponding to the Key for the paying account, followed by a Signature corresponding to the Key for each account that is sending or receiving cryptocurrency in the transfer. Each Transaction should not have more than 50 levels. 
  * The SignatureList field is deprecated and succeeded by SignatureMap.
  */
 message Transaction {
-    bytes signedTransactionBytes = 5; // SignedTransaction serialized into bytes
-    bytes bodyBytes = 4 [deprecated = true]; // TransactionBody serialized into bytes, which needs to be signed
+    TransactionBody body = 1 [deprecated = true]; // the body of the transaction, which needs to be signed
+    
+    SignatureList sigs = 2 [deprecated = true]; // The signatures on the body, to authorize the transaction; deprecated and to be succeeded by SignatureMap field
+    
     SignatureMap sigMap = 3 [deprecated = true]; // The signatures on the body with the new format, to authorize the transaction
+    
+    bytes bodyBytes = 4 [deprecated = true]; // TransactionBody serialized into bytes, which needs to be signed
+
+    bytes signedTransactionBytes = 5; // SignedTransaction serialized into bytes
 }

--- a/services/TransactionBody.proto
+++ b/services/TransactionBody.proto
@@ -68,6 +68,7 @@ import "TokenBurn.proto";
 import "TokenWipeAccount.proto";
 import "TokenAssociate.proto";
 import "TokenDissociate.proto";
+import "TokenFeeScheduleUpdate.proto";
 
 import "ScheduleCreate.proto";
 import "ScheduleDelete.proto";
@@ -121,6 +122,7 @@ message TransactionBody {
     TokenWipeAccountTransactionBody tokenWipe = 39; // Wipes amount of tokens from an account
     TokenAssociateTransactionBody tokenAssociate = 40; // Associate tokens to an account
     TokenDissociateTransactionBody tokenDissociate = 41; // Dissociate tokens from an account
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 45; // Updates a token's custom fee schedule
 
     ScheduleCreateTransactionBody scheduleCreate = 42; // Creates a schedule in the network's action queue
     ScheduleDeleteTransactionBody scheduleDelete = 43; // Deletes a schedule from the network's action queue

--- a/services/TransactionReceipt.proto
+++ b/services/TransactionReceipt.proto
@@ -101,7 +101,7 @@ message TransactionReceipt {
     // In the receipt of a CreateToken, the id of the newly created token
     TokenID tokenID = 10;
 
-    // In the receipt of TokenMint, TokenWipe, TokenBurn, the current total supply of this token
+    // In the receipt of TokenMint, TokenWipe, TokenBurn, For fungible tokens - the current total supply of this token. For non fungible tokens - the total number of NFTs issued for a given tokenID
     uint64 newTotalSupply = 11;
 
     // In the receipt of a ScheduleCreate, the id of the newly created Scheduled Entity

--- a/services/TransactionRecord.proto
+++ b/services/TransactionRecord.proto
@@ -27,6 +27,7 @@ option java_multiple_files = true;
 
 import "Timestamp.proto";
 import "BasicTypes.proto";
+import "CustomFees.proto";
 import "TransactionReceipt.proto";
 import "CryptoTransfer.proto";
 import "ContractCallLocal.proto";
@@ -46,4 +47,5 @@ message TransactionRecord {
     TransferList transferList = 10; // All hbar transfers as a result of this transaction, such as fees, or transfers performed by the transaction, or by a smart contract it calls, or by the creation of threshold records that it triggers.
     repeated TokenTransferList tokenTransferLists = 11; // All Token transfers as a result of this transaction
     ScheduleID scheduleRef = 12; // Reference to the scheduled transaction ID that this transaction record represent
+    repeated AssessedCustomFee assessed_custom_fees = 13; // All custom fees that were assessed during a CryptoTransfer, and must be paid if the transaction status resolved to SUCCESS
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
In the original implementation, the transaction fee payer account was responsible for paying the custom token fees. If the transaction fee-paying account did not have enough of the token to pay for the fee then INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE response was returned.

With the new implementation, the sender account is now responsible for paying the custom fees. When I see 'payer' in a response code I am thinking about the transaction fee payer account and not the sending account.

Update the response code to specify the sender account does not have enough token balance to pay for the custom fee.
INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE

**Related issue(s)**:

https://github.com/hashgraph/hedera-services/issues/1825

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
