### PR TITLE
064 d freeze txn use instant

### DIFF
--- a/services/Freeze.proto
+++ b/services/Freeze.proto
@@ -29,13 +29,13 @@ import "Duration.proto";
 import "Timestamp.proto";
 import "BasicTypes.proto";
 
-/* Set the freezing period in which the platform will stop creating events and accepting transactions. This is used before safely shut down the platform for maintenance. */
+/* At consensus, sets the consensus time at which the platform should stop creating events and accepting transactions, and enter a maintenance window. */
 message FreezeTransactionBody {
     int32 startHour = 1 [deprecated=true]; // The start hour (in UTC time), a value between 0 and 23
     int32 startMin = 2 [deprecated=true]; // The start minute (in UTC time), a value between 0 and 59
     int32 endHour = 3 [deprecated=true]; // The end hour (in UTC time), a value between 0 and 23
     int32 endMin = 4 [deprecated=true]; // The end minute (in UTC time), a value between 0 and 59
-    FileID updateFile = 5; // The ID of the file needs to be updated during a freeze transaction
-    bytes fileHash = 6; // The hash value of the file, used to verify file content before performing freeze and update
-    Timestamp startTime = 7; // the freeze start Timestamp
+    FileID update_file = 5; // If set, the file whose contents should be used for a network software update during the maintenance window
+    bytes file_hash = 6; // If set, the expected hash of the contents of the update file (used to verify the update)
+    Timestamp start_time = 7; // The consensus time at which the maintenance window should begin
 }

--- a/services/Freeze.proto
+++ b/services/Freeze.proto
@@ -38,5 +38,4 @@ message FreezeTransactionBody {
     FileID updateFile = 5; // The ID of the file needs to be updated during a freeze transaction
     bytes fileHash = 6; // The hash value of the file, used to verify file content before performing freeze and update
     Timestamp startTime = 7; // the freeze start Timestamp
-    Timestamp endTime = 8; // the freeze end Timestamp
 }

--- a/services/Freeze.proto
+++ b/services/Freeze.proto
@@ -31,10 +31,12 @@ import "BasicTypes.proto";
 
 /* Set the freezing period in which the platform will stop creating events and accepting transactions. This is used before safely shut down the platform for maintenance. */
 message FreezeTransactionBody {
-    int32 startHour = 1; // The start hour (in UTC time), a value between 0 and 23
-    int32 startMin = 2; // The start minute (in UTC time), a value between 0 and 59
-    int32 endHour = 3; // The end hour (in UTC time), a value between 0 and 23
-    int32 endMin = 4; // The end minute (in UTC time), a value between 0 and 59
+    int32 startHour = 1 [deprecated=true]; // The start hour (in UTC time), a value between 0 and 23
+    int32 startMin = 2 [deprecated=true]; // The start minute (in UTC time), a value between 0 and 59
+    int32 endHour = 3 [deprecated=true]; // The end hour (in UTC time), a value between 0 and 23
+    int32 endMin = 4 [deprecated=true]; // The end minute (in UTC time), a value between 0 and 59
     FileID updateFile = 5; // The ID of the file needs to be updated during a freeze transaction
     bytes fileHash = 6; // The hash value of the file, used to verify file content before performing freeze and update
+    Timestamp startTime = 7; // the freeze start Timestamp
+    Timestamp endTime = 8; // the freeze end Timestamp
 }


### PR DESCRIPTION
**Description**:
This PR added a new field Timestamp as freeze start time, meanwhile deprecated these 4 fields as freeze start time and duration:

1. startHour
2. startMin
3. endHout
4. endMin


Now once hedera services enter `MAINTENANCE` mode, it has to be manually taken down and up.


**Related issue(s)**:

Fixes #64


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
