### PR TITLE
Add effective fee payers to transaction record

### DIFF
--- a/services/CustomFees.proto
+++ b/services/CustomFees.proto
@@ -59,4 +59,5 @@ message AssessedCustomFee {
   int64 amount = 1; // The number of units assessed for the fee
   TokenID token_id = 2; // The denomination of the fee; taken as hbar if left unset
   AccountID fee_collector_account_id = 3; // The account to receive the assessed fee
+  repeated AccountID effective_payer_account_id = 4; // The account(s) whose final balances would have been higher in the absence of this assessed fee
 }

--- a/services/ResponseCode.proto
+++ b/services/ResponseCode.proto
@@ -269,5 +269,5 @@ enum ResponseCodeEnum {
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH = 257; // The reference chain of custom fees for a transferred token exceeded the maximum length of 2
   CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS = 258; // More than 20 balance adjustments were to satisfy a CryptoTransfer and its implied custom fee payments
   INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE = 259; // The sender account in the token transfer transaction could not afford a custom fee
-
+  SERIAL_NUMBER_LIMIT_REACHED = 260; // Currently no more than 4,294,967,295 NFTs may be minted for a given unique token type
 }


### PR DESCRIPTION
**Description**:
 - Add a `repeated AccountID effective_payer_account_id` to the `AssessedCustomFee` message.

**Related issue(s)**:
 - Needed for https://github.com/hashgraph/hedera-services/issues/1938
