### PR TITLE
Change max_automatic_token_associations to int32

### DIFF
--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -129,5 +129,5 @@ message CryptoCreateTransactionBody {
      * The maximum number of tokens that an Account can be implicitly associated with. Defaults to 0
      * and up to a maximum value of 1000.
      */
-    uint32 max_automatic_token_associations = 14;
+    int32 max_automatic_token_associations = 14;
 }

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -156,7 +156,7 @@ message CryptoGetInfoResponse {
         /**
          * The maximum number of tokens that an Account can be implicitly associated with.
          */
-        uint32 max_automatic_token_associations = 18;
+        int32 max_automatic_token_associations = 18;
     }
 
     /**

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -128,5 +128,5 @@ message CryptoUpdateTransactionBody {
      * The maximum number of tokens that an Account can be implicitly associated with. Up to a 1000
      * including implicit and explicit associations.
      */
-    google.protobuf.UInt32Value max_automatic_token_associations = 15;
+    google.protobuf.Int32Value max_automatic_token_associations = 15;
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes the type of `max_automatic_token_associations` to `int32` / `Int32Value`. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The corresponding type of protobuf `uint32` in Java is `int`. Since the allowed value will never be more than int32 max, we should change it to `int32` to avoid unnecessary unsigned conversion in Java code. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
