### PR TITLE
Add (dev-only) `NetworkService.getExecutionTime` query

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -981,6 +981,11 @@ enum HederaFunctionality {
      * Update a token's custom fee schedule, if permissible
      */
     TokenFeeScheduleUpdate = 77;
+
+    /**
+     * Get execution time(s) by TransactionID, if available
+     */
+    NetworkGetExecutionTime = 78;
 }
 
 /**

--- a/services/network_get_execution_time.proto
+++ b/services/network_get_execution_time.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Gets the time in nanoseconds spent in <tt>handleTransaction</tt> for one or more 
+ * TransactionIDs (assuming they have reached consensus "recently", since only a limited 
+ * number of execution times are kept in-memory, depending on the value of the node-local 
+ * property <tt>stats.executionTimesToTrack</tt>).
+ */
+message NetworkGetExecutionTimeQuery {
+  /**
+   * standard info sent from client to node including the signed payment, and what kind of response
+   * is requested (cost, state proof, both, or neither).
+   */
+  QueryHeader header = 1;
+
+  /**
+   * The id(s) of the transactions to get the execution time(s) of
+   */
+  repeated TransactionID transaction_ids = 2;
+}
+
+/**
+ * Response when the client sends the node NetworkGetExecutionTimeQuery; returns
+ * INVALID_TRANSACTION_ID if any of the given TransactionIDs do not have available
+ * execution times in the answering node.
+ */
+message NetworkGetExecutionTimeResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The execution time(s) of the requested TransactionIDs, if available
+     */
+    repeated uint64 execution_times = 2;
+}

--- a/services/network_service.proto
+++ b/services/network_service.proto
@@ -39,6 +39,14 @@ service NetworkService {
     rpc getVersionInfo (Query) returns (Response);
 
     /**
+     * Retrieves the time in nanoseconds spent in <tt>handleTransaction</tt> for one or more 
+     * TransactionIDs (assuming they have reached consensus "recently", since only a limited 
+     * number of execution times are kept in-memory, depending on the value of the node-local 
+     * property <tt>stats.executionTimesToTrack</tt>).
+     */
+    rpc getExecutionTime (Query) returns (Response);
+
+    /**
      * Submits a "wrapped" transaction to the network, skipping its standard prechecks. (Note that
      * the "wrapper" <tt>UncheckedSubmit</tt> transaction is still subject to normal prechecks,
      * including an authorization requirement that its payer be either the treasury or system admin

--- a/services/query.proto
+++ b/services/query.proto
@@ -49,6 +49,8 @@ import "transaction_get_fast_record.proto";
 import "consensus_get_topic_info.proto";
 
 import "network_get_version_info.proto";
+import "network_get_execution_time.proto";
+
 import "token_get_info.proto";
 import "schedule_get_info.proto";
 
@@ -182,5 +184,10 @@ message Query {
          * Get a list of NFTs for the token
          */
         TokenGetNftInfosQuery tokenGetNftInfos = 56;
+
+        /**
+         * Gets <tt>handleTransaction</tt> times for one or more "sufficiently recent" TransactionIDs
+         */
+        NetworkGetExecutionTimeQuery networkGetExecutionTime = 57;
     }
 }

--- a/services/response.proto
+++ b/services/response.proto
@@ -49,6 +49,7 @@ import "transaction_get_fast_record.proto";
 import "consensus_get_topic_info.proto";
 
 import "network_get_version_info.proto";
+import "network_get_execution_time.proto";
 
 import "token_get_account_nft_infos.proto";
 import "token_get_info.proto";
@@ -178,5 +179,10 @@ message Response {
          * A list of the NFTs for the token
          */
         TokenGetNftInfosResponse tokenGetNftInfos = 156;
+
+        /**
+         * Execution times of "sufficiently recent" transactions
+         */
+        NetworkGetExecutionTimeResponse networkGetExecutionTime = 157;
     }
 }


### PR DESCRIPTION
**Related issue(s)**:

Needed for https://github.com/hashgraph/hedera-services/issues/2099

**Notes for reviewer**:
- Some kinds of performance tests need fine-grained information on time spent handling specific `TransactionID`s.
- Without client-side access to this timing information, it becomes difficult to write self-validating perf tests.
- The new `NetworkService.getExecutionTime` query will only be enabled in DEV environments, to support such performance tests.