### PR TITLE
Remove deprecated freeze transaction fields and add `FreezeType` enum

### DIFF
--- a/services/freeze.proto
+++ b/services/freeze.proto
@@ -28,6 +28,7 @@ option java_multiple_files = true;
 import "duration.proto";
 import "timestamp.proto";
 import "basic_types.proto";
+import "freeze_type.proto";
 
 /**
  * At consensus, sets the consensus time at which the platform should stop creating events and
@@ -35,38 +36,33 @@ import "basic_types.proto";
  */
 message FreezeTransactionBody {
     /**
-     * The start hour (in UTC time), a value between 0 and 23
-     */
-    int32 startHour = 1 [deprecated=true];
-
-    /**
-     * The start minute (in UTC time), a value between 0 and 59
-     */
-    int32 startMin = 2 [deprecated=true];
-
-    /**
-     * The end hour (in UTC time), a value between 0 and 23
-     */
-    int32 endHour = 3 [deprecated=true];
-
-    /**
-     * The end minute (in UTC time), a value between 0 and 59
-     */
-    int32 endMin = 4 [deprecated=true];
-
-    /**
      * If set, the file whose contents should be used for a network software update during the
-     * maintenance window
+     * maintenance window.
      */
     FileID update_file = 5;
 
     /**
-     * If set, the expected hash of the contents of the update file (used to verify the update)
+     * If set, the expected hash of the contents of the update file (used to verify the update).
      */
     bytes file_hash = 6;
 
     /**
-     * The consensus time at which the maintenance window should begin
+     * The consensus time at which the maintenance window should begin.
      */
     Timestamp start_time = 7;
+
+    /**
+     * The type of network freeze or upgrade operation to perform.
+     */
+    FreezeType freeze_type = 8;
+    
+    /**
+     * Reserve deleted field identifiers to prevent reuse.
+     */
+    reserved 1, 2, 3, 4;
+
+    /**
+     * Reserve deleted field names to prevent reuse.
+     */ 
+    reserved "startHour", "startMin", "endHour", "endMin";
 }

--- a/services/freeze_type.proto
+++ b/services/freeze_type.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+/**
+* The type of network freeze or upgrade operation to be performed. This type dictates which 
+* fields are required. 
+*/
+enum FreezeType {
+    /**
+     * Freezes the network at the specified time. The start_time field must be provided and 
+     * must reference a future time. Any values specified for the update_file and file_hash 
+     * fields will be ignored. This transaction does not perform any network changes or 
+     * upgrades and requires manual intervention to restart the network. 
+     */
+    FREEZE_ONLY = 0; 
+
+    /**
+     * A non-freezing operation that initiates network wide preparation in advance of a 
+     * scheduled freeze upgrade. The update_file and file_hash fields must be provided and 
+     * valid. The start_time field may be omitted and any value present will be ignored.
+     */
+    PREPARE_UPGRADE = 1; 
+
+    /**
+     * Freezes the network at the specified time and performs the previously prepared 
+     * automatic upgrade across the entire network. 
+     */
+    FREEZE_UPGRADE = 2; 
+
+    /**
+     * Aborts a pending network freeze operation.
+     */
+    FREEZE_ABORT = 3; 
+
+    /**
+     * Performs an immediate upgrade on auxilary services and containers providing 
+     * telemetry/metrics. Does not impact network operations. 
+     */
+    TELEMETRY_UPGRADE = 4; 
+}

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1005,7 +1005,18 @@ enum ResponseCodeEnum {
   EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT = 263;
 
   /**
-   * Cannot set the number of automatic associations for an account more than the maximum allowed token associations <tt>tokens.maxPerAccount</tt>
+   * Cannot set the number of automatic associations for an account more than the maximum allowed 
+   * token associations <tt>tokens.maxPerAccount</tt>.
    */
   REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT = 264;
+
+  /** 
+   * The update file in a freeze transaction body must exist.
+   */
+  FREEZE_UPDATE_FILE_DOES_NOT_EXIST = 265;
+
+  /** 
+   * The hash of the update file in a freeze transaction body must match the in-memory hash.
+   */
+  FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH = 266;
 }


### PR DESCRIPTION
**Description**:
- Remove deprecated fields from `FreezeTransactionBody`.
- Add `FreezeType` enum to control handling of `Freeze` transactions.
- Add two response codes for freeze-specific failure modes.