### PR TITLE
Fix/clarify some comments

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1180,8 +1180,8 @@ message NodeAddress {
 
     /**
      * Hex encoding of the node's X509 RSA public key used to sign stream files (e.g., record 
-     * stream files). That is, this field is a string of hexadecimal characters which, translated 
-     * to binary, are the public key's DER encoding.  
+     * stream files). Specifically, this field is a string of hexadecimal characters which, 
+     * translated to binary, are the public key's DER encoding.  
      */
     string RSA_PubKey = 4;
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1179,7 +1179,9 @@ message NodeAddress {
     bytes memo = 3 [deprecated=true];
 
     /**
-     * The node's hex-encoded X509 RSA public key
+     * Hex encoding of the node's X509 RSA public key used to sign stream files (e.g., record 
+     * stream files). That is, this field is a string of hexadecimal characters which, translated 
+     * to binary, are the public key's DER encoding.  
      */
     string RSA_PubKey = 4;
 
@@ -1194,7 +1196,10 @@ message NodeAddress {
     AccountID nodeAccountId = 6;
 
     /**
-     * # The hex-encoded SHA-384 hash of the X509 cert used to encrypt gRPC traffic to the node
+     * # Hex encoding of the SHA-384 hash of the TLS cert the node uses to encrypt gRPC 
+     * traffic (in UTF-8 NKFD). Specifically, this field is a string of hexadecimal characters 
+     * which, translated to binary, are the SHA-384 hash of the UTF-8 NKFD representation of 
+     * the node's TLS cert in PEM format.
      */
     bytes nodeCertHash = 7;
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1179,8 +1179,8 @@ message NodeAddress {
     bytes memo = 3 [deprecated=true];
 
     /**
-     * Hex encoding of the node's X509 RSA public key used to sign stream files (e.g., record 
-     * stream files). Specifically, this field is a string of hexadecimal characters which, 
+     * The node's X509 RSA public key used to sign stream files (e.g., record stream 
+     * files). Precisely, this field is a string of hexadecimal characters which, 
      * translated to binary, are the public key's DER encoding.  
      */
     string RSA_PubKey = 4;
@@ -1196,10 +1196,10 @@ message NodeAddress {
     AccountID nodeAccountId = 6;
 
     /**
-     * # Hex encoding of the SHA-384 hash of the TLS cert the node uses to encrypt gRPC 
-     * traffic (in UTF-8 NKFD). Specifically, this field is a string of hexadecimal characters 
-     * which, translated to binary, are the SHA-384 hash of the UTF-8 NKFD representation of 
-     * the node's TLS cert in PEM format.
+     * # Hash of the node's TLS certificate. Precisely, this field is a string of 
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of 
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be 
+     * used to verify the node's certificate it presents during TLS negotiations.
      */
     bytes nodeCertHash = 7;
 

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -63,7 +63,7 @@ enum ResponseCodeEnum {
 
   /**
    * The given transactionValidDuration was either non-positive, or greater than the maximum 
-   * valid duration of 180 secs (set by Services property hedera.transaction.maxValidDuration).
+   * valid duration of 180 secs.
    * 
    */
   INVALID_TRANSACTION_DURATION = 6;

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -62,7 +62,9 @@ enum ResponseCodeEnum {
   INVALID_TRANSACTION_START = 5;
 
   /**
-   * valid transaction duration is a positive non zero number that does not exceed 120 seconds
+   * The given transactionValidDuration was either non-positive, or greater than the maximum 
+   * valid duration of 180 secs (set by Services property hedera.transaction.maxValidDuration).
+   * 
    */
   INVALID_TRANSACTION_DURATION = 6;
 


### PR DESCRIPTION
**Description**:
- Clarify how to interpret the hashes in `NodeAddress`.
- Fix the actual value of [`hedera.transaction.maxValidDuration=180`](https://github.com/hashgraph/hedera-services/blob/master/hedera-node/src/main/resources/bootstrap.properties#L57) in use on production networks.