### PR TITLE
deprecate: Deprecate maxResultSize and fileID

### DIFF
--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -133,7 +133,7 @@ message ContractCallLocalQuery {
     /**
      * max number of bytes that the result might include. The run will fail if it would have returned more than this number of bytes.
      */
-    int64 maxResultSize = 5;
+    int64 maxResultSize = 5 [deprecated=true];
 }
 
 /**

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -79,7 +79,7 @@ message ContractUpdateTransactionBody {
      * The new id of the file asserted to contain the bytecode of the Solidity transaction that
      * created this contract
      */
-    FileID fileID = 8;
+    FileID fileID = 8 [deprecated = true];
 
     /**
      * The new contract memo, assumed to be Unicode encoded with UTF-8 (at most 100 bytes)


### PR DESCRIPTION
Signed-off-by: Daniel Ivanov daniel.k.ivanov95@gmail.com

Description:
- Deprecates already ignored property fileID from the ContractUpdate operation
- Deprecates maxResultSize -> Property is being ignored in 0.19

Checklist

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)