### PR TITLE
Add minimal protobuf support for the BLS protocol

### DIFF
--- a/services/bls_protocol_type.proto
+++ b/services/bls_protocol_type.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+/**
+* The types of BLS protocols that may be initiated.
+*/
+enum BlsProtocolType {
+    /**
+     * An (invalid) default value for this enum, to ensure the client explicitly sets 
+     * the intended type of BLS protocol to initiate.
+     */
+    UNKNOWN = 0; 
+
+    /**
+     * Initiates the genesis protocol to first, derive the common reference string (CRS); 
+     * and second, invoke the distributed key generation.
+     * 
+     * Note that the second stage occurs only if the first succeeds; the status of 
+     * each stage may be requested using the network service getBlsProtocolStatus query.
+     */
+    GENESIS = 1; 
+
+    /**
+     * Initiates the protocol to compute a resharing of the distributed private key.
+     */
+    REKEY = 2; 
+}

--- a/services/initiate_bls_protocol.proto
+++ b/services/initiate_bls_protocol.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "duration.proto";
+
+/**
+ * Initiates a given type BLS protocol. Transaction payer must have superuser privileges 
+ * (account 0.0.2 or 0.0.50).
+ */
+message InitiateBlsProtocolBody {
+  /**
+  * The choice of BLS protocol type to initiate.
+  */
+  BlsProtocolType bls_protocol_type = 1;      
+
+  /**
+   * The maximum time allowed for each protocol stage.
+   */
+  Duration phase_duration = 2;
+}

--- a/services/network_service.proto
+++ b/services/network_service.proto
@@ -47,6 +47,12 @@ service NetworkService {
     rpc getExecutionTime (Query) returns (Response);
 
     /**
+     * Initiates a given stage of the BLS protocol. Transaction payer must have superuser 
+     * privileges (account 0.0.2 or 0.0.50).
+     */
+    rpc initiateBlsProtocol (Transaction) returns (TransactionResponse);
+
+    /**
      * Submits a "wrapped" transaction to the network, skipping its standard prechecks. (Note that
      * the "wrapper" <tt>UncheckedSubmit</tt> transaction is still subject to normal prechecks,
      * including an authorization requirement that its payer be either the treasury or system admin

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1093,4 +1093,9 @@ enum ResponseCodeEnum {
    * consensus level.
    */
   CONSENSUS_GAS_EXHAUSTED = 279;
+
+  /**
+   * The provided BLS phase duration was not adequate for the protocol.
+   */
+  INSUFFICIENT_BLS_PHASE_DURATION = 280;
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -314,5 +314,10 @@ message TransactionBody {
      * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
      */
     ScheduleSignTransactionBody scheduleSign = 44;
+
+    /**
+     * Initiates a given type BLS protocol
+     */
+    InitiateBlsProtocolBody initiateBlsProtocol = 45;
   }
 }


### PR DESCRIPTION
**Description**:
- Add a `NetworkService.initiateBlsProtocol` transaction to initiate either the `GENESIS` or `REKEY` protocol.