### PR TITLE
Protobuf changes for HIP-206

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -158,13 +158,14 @@ message TransactionID {
     bool scheduled = 3;
 
     /**
-     * The unique id of a "child" transaction that was executed on behalf of 
-     * a parent transaction. (Children share the transactionValidStart and
-     * accountID of their parent.) 
+     * The identifier for an internal transaction that was spawned as part 
+     * of handling a user transaction. (These internal transactions share the 
+     * transactionValidStart and accountID of the user transaction, so a
+     * nonce is necessary to give them a unique TransactionID.)
      * 
-     * Note a parent transaction can spawn multiple child transactions. Examples 
-     * include precompiled contracts executed during a top-level ContractCreate 
-     * or ContractCall.
+     * An example is when a "parent" ContractCreate or ContractCall transaction 
+     * calls one or more HTS precompiled contracts; each of the "child" 
+     * transactions spawned for a precompile has a id with a different nonce.
      */
     int32 nonce = 4;
 }

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -156,6 +156,17 @@ message TransactionID {
      * Whether the Transaction is of type Scheduled or no
      */
     bool scheduled = 3;
+
+    /**
+     * The unique id of a "child" transaction that was executed on behalf of 
+     * a parent transaction. (Children share the transactionValidStart and
+     * accountID of their parent.) 
+     * 
+     * Note a parent transaction can spawn multiple child transactions. Examples 
+     * include precompiled contracts executed during a top-level ContractCreate 
+     * or ContractCall.
+     */
+    int32 nonce = 4;
 }
 
 /**
@@ -521,6 +532,16 @@ message Key {
          * Compressed ECDSA(secp256k1) public key bytes
          */
         bytes ECDSA_secp256k1 = 7;
+
+        /**  
+         * A smart contract that, if the recipient of the active message frame, should be treated
+         * as having signed. (Note this does not mean the <i>code being executed in the frame</i> 
+         * will belong to the given contract, since it could be running another contract's code via 
+         * <tt>delegatecall</tt>. So setting this key is a more permissive version of setting the
+         * contractID key, which also requires the code in the active message frame belong to the
+         * the contract with the given id.)
+         */
+        ContractID delegatable_contract_id = 8; 
     }
 }
 

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1093,4 +1093,14 @@ enum ResponseCodeEnum {
    * consensus level.
    */
   CONSENSUS_GAS_EXHAUSTED = 279;
+
+  /**
+   * A precompiled contract succeeded, but was later reverted.
+   */
+  REVERTED_SUCCESS = 280;
+
+  /**
+   * All contract storage allocated to the current price regime has been consumed.
+   */
+  MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED = 281;
 }

--- a/services/transaction_get_receipt.proto
+++ b/services/transaction_get_receipt.proto
@@ -54,10 +54,17 @@ message TransactionGetReceiptQuery {
      * receipt of processing the first consensus transaction with the given id whose status was
      * neither <tt>INVALID_NODE_ACCOUNT</tt> nor <tt>INVALID_PAYER_SIGNATURE</tt>; <b>or</b>, if no
      * such receipt exists, the receipt of processing the first transaction to reach consensus with
-     * the given transaction id..
+     * the given transaction id.
      */
     bool includeDuplicates = 3;
+
+    /**
+     * Whether the response should include the receipts of any child transactions spawned by the 
+     * top-level transaction with the given transactionID. 
+     */
+    bool include_child_receipts = 4;
 }
+
 /**
  * Response when the client sends the node TransactionGetReceiptQuery. If it created a new entity
  * (account, file, or smart contract instance) then one of the three ID fields will be filled in
@@ -81,8 +88,13 @@ message TransactionGetReceiptResponse {
     TransactionReceipt receipt = 2;
 
     /**
-     * The receipts of processing all consensus transaction with the same id as the distinguished
-     * receipt above, in chronological order.
+     * The receipts of processing all transactions with the given id, in consensus time order.
      */
     repeated TransactionReceipt duplicateTransactionReceipts = 4;
+
+    /**
+     * The receipts (if any) of all child transactions spawned by the transaction with the 
+     * given top-level id, in consensus order. Always empty if the top-level status is UNKNOWN.
+     */
+    repeated TransactionReceipt child_transaction_receipts = 5;
 }

--- a/services/transaction_get_record.proto
+++ b/services/transaction_get_record.proto
@@ -59,6 +59,12 @@ message TransactionGetRecordQuery {
      * given transaction id..
      */
     bool includeDuplicates = 3;
+
+    /**
+     * Whether the response should include the records of any child transactions spawned by the 
+     * top-level transaction with the given transactionID. 
+     */
+    bool include_child_records = 4;
 }
 
 /**
@@ -84,5 +90,11 @@ message TransactionGetRecordResponse {
      * record above, in chronological order.
      */
     repeated TransactionRecord duplicateTransactionRecords = 4;
+
+    /**
+     * The records of processing all child transaction spawned by the transaction with the given 
+     * top-level id, in consensus order. Always empty if the top-level status is UNKNOWN.
+     */
+    repeated TransactionRecord child_transaction_records = 5;
 }
 

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -112,7 +112,8 @@ message TransactionRecord {
     repeated TokenAssociation automatic_token_associations = 14;
 
     /**
-     * In the record of a "child" transaction, the consensus timestamp of its parent.
+     * In the record of an internal transaction, the consensus timestamp of the user 
+     * transaction that spawned it.
      */
     Timestamp parent_consensus_timestamp = 15;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -110,4 +110,9 @@ message TransactionRecord {
      * All token associations implicitly created while handling this transaction
      */
     repeated TokenAssociation automatic_token_associations = 14;
+
+    /**
+     * In the record of a "child" transaction, the consensus timestamp of its parent.
+     */
+    Timestamp parent_consensus_timestamp = 15;
 }


### PR DESCRIPTION
**Description**:
- Adds response codes `REVERTED_SUCCESS` and `MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED`.
- Supports child records via `TransactionID#nonce` and `TransactionRecord#parent_consensus_timestamp`.
- Permits querying for child receipts and records by parent `TransactionID`.
- Adds `delegatable_contract_id` key type.