### PR TITLE
Auto account creation changes

### DIFF
--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1103,4 +1103,9 @@ enum ResponseCodeEnum {
    * All contract storage allocated to the current price regime has been consumed.
    */
   MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED = 281;
+
+  /**
+   * Alias provided in the CryptoTransfer transaction is not a valid serialized primitive Key
+   */
+  INVALID_ALIAS = 282;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1105,7 +1105,9 @@ enum ResponseCodeEnum {
   MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED = 281;
 
   /**
-   * Alias provided in the CryptoTransfer transaction is not a valid serialized primitive Key
+   * An alias used in a CryptoTransfer transaction is not the serializion of a primitive Key 
+   * message--that is, a Key with a single Ed25519 or ECDSA(secp256k1) public key and no 
+   * unknown protobuf fields.
    */
-  INVALID_ALIAS = 282;
+  INVALID_ALIAS_KEY = 282;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1105,7 +1105,7 @@ enum ResponseCodeEnum {
   MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED = 281;
 
   /**
-   * An alias used in a CryptoTransfer transaction is not the serializion of a primitive Key 
+   * An alias used in a CryptoTransfer transaction is not the serialization of a primitive Key
    * message--that is, a Key with a single Ed25519 or ECDSA(secp256k1) public key and no 
    * unknown protobuf fields.
    */

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -118,8 +118,8 @@ message TransactionRecord {
     Timestamp parent_consensus_timestamp = 15;
 
     /**
-     * In the record of an internal CryptoCreate transaction triggered by a CryptoTransfer to the alias,
-     * decoded alias of the auto created account
+     * In the record of an internal CryptoCreate transaction triggered by a CryptoTransfer 
+     * to a (previously unsed) alias, the new account's alias. 
      */
      bytes alias = 16;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -119,7 +119,7 @@ message TransactionRecord {
 
     /**
      * In the record of an internal CryptoCreate transaction triggered by a user 
-     * transaction to a (previously unused) alias, the new account's alias. 
+     * transaction with a (previously unused) alias, the new account's alias. 
      */
      bytes alias = 16;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -118,8 +118,8 @@ message TransactionRecord {
     Timestamp parent_consensus_timestamp = 15;
 
     /**
-     * In the record of an internal CryptoCreate transaction triggered by a CryptoTransfer 
-     * to a (previously unsed) alias, the new account's alias. 
+     * In the record of an internal CryptoCreate transaction triggered by a user 
+     * transaction to a (previously unused) alias, the new account's alias. 
      */
      bytes alias = 16;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -116,4 +116,10 @@ message TransactionRecord {
      * transaction that spawned it.
      */
     Timestamp parent_consensus_timestamp = 15;
+
+    /**
+     * In the record of an internal CryptoCreate transaction triggered by a CryptoTransfer to the alias,
+     * decoded alias of the auto created account
+     */
+     bytes alias = 16;
 }


### PR DESCRIPTION
Related to #118 

1. Added a Response code `INVALID_ALIAS` when the alias is not valid primitive key
2. Added `alias` to transaction record that will be set for `CryptoCreate` transaction record