### PR TITLE
Support HIP-31

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -23,6 +23,7 @@ package proto;
  */
 
 import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
@@ -264,6 +265,12 @@ message TokenTransferList {
      * which has a sender and receiver account, including the serial number of the NFT
      */
     repeated NftTransfer nftTransfers = 3;
+
+    /**
+     * If present, the number of decimals this fungible token type is expected to have. The transfer
+     * will fail with UNEXPECTED_TOKEN_DECIMALS if the actual decimals differ.
+     */
+    google.protobuf.Int32Value expected_decimals = 4;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -270,7 +270,7 @@ message TokenTransferList {
      * If present, the number of decimals this fungible token type is expected to have. The transfer
      * will fail with UNEXPECTED_TOKEN_DECIMALS if the actual decimals differ.
      */
-    google.protobuf.Int32Value expected_decimals = 4;
+    google.protobuf.UInt32Value expected_decimals = 4;
 }
 
 /**

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1110,4 +1110,10 @@ enum ResponseCodeEnum {
    * unknown protobuf fields.
    */
   INVALID_ALIAS_KEY = 282;
+
+  /**
+   * A fungible token transfer expected a different number of decimals than the involved 
+   * type actually has.
+   */
+  UNEXPECTED_TOKEN_DECIMALS = 283;
 }


### PR DESCRIPTION
**Description**:
- Adds a `TokenTransferList#expected_decimals` field so clients can stipulate a fungible token transfer will only succeed if the actual decimals match the field's value.
- Adds a `UNEXPECTED_TOKEN_DECIMALS` for the failure case.