### PR TITLE
Support HIP-21

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1068,6 +1068,11 @@ enum HederaFunctionality {
      * Unpause the Token
      */
     TokenUnpause = 80;
+
+    /**
+     * Get freely available network info, especially the address book
+     */
+    NetworkGetInfo = 81;
 }
 
 /**

--- a/services/network_get_info.proto
+++ b/services/network_get_info.proto
@@ -57,4 +57,9 @@ message NetworkGetInfoResponse {
      * type for more details.
      */
     NodeAddressBook node_address_book = 2;
+
+    /**
+     * The ledger ID of this network. Please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
+     */
+    bytes ledger_id = 3;
 }

--- a/services/network_get_info.proto
+++ b/services/network_get_info.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get freely available information about the target network, especially its address book.
+ */
+message NetworkGetInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+}
+
+/**
+ * Response to a NetworkGetInfoQuery
+ */
+message NetworkGetInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The network <i>address book</i>, which includes not just the IP addresses of the network 
+     * nodes, but also the the cryptographic keys they use to sign transactions and do TLS. Please 
+     * see the <a href="https://hashgraph.github.io/hedera-protobufs/#proto.NodeAddress"><tt>NodeAddress</tt></a>
+     * type for more details.
+     */
+    NodeAddressBook node_address_book = 2;
+}

--- a/services/network_service.proto
+++ b/services/network_service.proto
@@ -34,9 +34,18 @@ import "transaction.proto";
  */
 service NetworkService {
     /**
-     * Retrieves the active versions of Hedera Services and HAPI proto
+     * Retrieves the active versions of Hedera Services and HAPI proto. Not a free query.
      */
     rpc getVersionInfo (Query) returns (Response);
+
+    /**
+     * Retrieves free metadata about the network, most importantly its <i>address book</i>. 
+     * The address book includes not just the IP addresses of the network nodes, but also the 
+     * the cryptographic keys they use to sign transactions and do TLS. Please see the
+     * <a href="https://hashgraph.github.io/hedera-protobufs/#proto.NodeAddress"><tt>NodeAddress</tt></a>
+     * type for more details.
+     */
+    rpc getNetworkInfo (Query) returns (Response);
 
     /**
      * Retrieves the time in nanoseconds spent in <tt>handleTransaction</tt> for one or more 

--- a/services/query.proto
+++ b/services/query.proto
@@ -50,6 +50,7 @@ import "consensus_get_topic_info.proto";
 
 import "network_get_version_info.proto";
 import "network_get_execution_time.proto";
+import "network_get_info.proto";
 
 import "token_get_info.proto";
 import "schedule_get_info.proto";
@@ -163,12 +164,10 @@ message Query {
          */
         TokenGetInfoQuery tokenGetInfo = 52;
 
-
         /**
          * Get all information about a scheduled entity
          */
         ScheduleGetInfoQuery scheduleGetInfo = 53;
-
 
         /**
          * Get a list of NFTs associated with the account
@@ -189,5 +188,10 @@ message Query {
          * Gets <tt>handleTransaction</tt> times for one or more "sufficiently recent" TransactionIDs
          */
         NetworkGetExecutionTimeQuery networkGetExecutionTime = 57;
+
+        /**
+         * Gets network information including the address book.
+         */
+        NetworkGetInfoQuery network_get_info = 58;
     }
 }


### PR DESCRIPTION
**Description**:
- Adds a `NetworkGetInfo` query to the `NetworkService` to return the address book and ledger ID.

❓ &nbsp;_Question for reviewers_: Would it make sense to deprecate the `NetworkGetVersionInfo` query and include that information in the `NetworkGetInfo` query? Note that `NetworkGetVersionInfo` is currently **not** free, and `NetworkGetInfo` is to be free.