### PR TITLE
Additional response codes for extending alias support

### DIFF
--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -129,4 +129,12 @@ message CryptoUpdateTransactionBody {
      * including implicit and explicit associations.
      */
     google.protobuf.Int32Value max_automatic_token_associations = 15;
+
+    /**
+     * If set, the new public key bytes to be used as the account's alias. Alias can be updated
+     * only on accounts that does not have it set previously. It will be immutable once it is
+     * set on an account. For successful update of alias, the corresponding alias private key
+     * should sign the transaction.
+     */
+    bytes alias = 16;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1131,4 +1131,9 @@ enum ResponseCodeEnum {
    * The fee collector account id in TokenFeeScheduleUpdate is invalid or does not exist.
    */
   INVALID_FEE_COLLECTOR_ACCOUNT_ID = 286;
+
+  /**
+   * The alias already set on an account cannot be updated using CryptoUpdate transaction.
+   */
+  ALIAS_IS_IMMUTABLE = 287;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1118,7 +1118,7 @@ enum ResponseCodeEnum {
   UNEXPECTED_TOKEN_DECIMALS = 283;
 
   /**
-   * The proxy account id is invalid or does not exist,
+   * The proxy account id is invalid or does not exist.
    */
   INVALID_PROXY_ACCOUNT_ID = 284;
 

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1131,9 +1131,4 @@ enum ResponseCodeEnum {
    * The fee collector account id in TokenFeeScheduleUpdate is invalid or does not exist.
    */
   INVALID_FEE_COLLECTOR_ACCOUNT_ID = 286;
-
-  /**
-   * The auto renew account id is invalid or does not exist.
-   */
-  INVALID_AUTORENEW_ACCOUNT_ID = 287;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -476,12 +476,12 @@ enum ResponseCodeEnum {
   /**
    * [Deprecated]. attempt to set negative receive record threshold
    */
-  INVALID_RECEIVE_RECORD_THRESHOLD = 86 [deprecated=true];
+  INVALID_RECEIVE_RECORD_THRESHOLD = 86 [deprecated = true];
 
   /**
    * [Deprecated]. attempt to set negative send record threshold
    */
-  INVALID_SEND_RECORD_THRESHOLD = 87 [deprecated=true];
+  INVALID_SEND_RECORD_THRESHOLD = 87 [deprecated = true];
 
   /**
    * Special Account Operations should be performed by only Genesis account, return this code if it
@@ -1116,4 +1116,24 @@ enum ResponseCodeEnum {
    * type actually has.
    */
   UNEXPECTED_TOKEN_DECIMALS = 283;
+
+  /**
+   * The proxy account id is invalid or does not exist,
+   */
+  INVALID_PROXY_ACCOUNT_ID = 284;
+
+  /**
+   * The transfer account id in CryptoDelete transaction is invalid or does not exist.
+   */
+  INVALID_TRANSFER_ACCOUNT_ID = 285;
+
+  /**
+   * The fee collector account id in TokenFeeScheduleUpdate is invalid or does not exist.
+   */
+  INVALID_FEE_COLLECTOR_ACCOUNT_ID = 286;
+
+  /**
+   * The auto renew account id is invalid or does not exist.
+   */
+  INVALID_AUTORENEW_ACCOUNT_ID = 287;
 }


### PR DESCRIPTION
Closes #134 

For extending alias support to all transactions and Queries, added additional response codes to be returned if account ID given is invalid or does not exist.