### PR TITLE
Populate `evm_address` in contract create record and support use in HAPI 

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -142,7 +142,7 @@ message ContractID {
 
     oneof contract {
         /**
-        * A nonnegative number unique within its realm
+        * A nonnegative number unique within a given shard and realm
         */
         int64 contractNum = 3;
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -147,10 +147,19 @@ message ContractID {
         int64 contractNum = 3;
 
         /**
-        * The 20-byte EVM address of the contract to call. Note that if the 
-        * target contract was created via CREATE2, its address will have 
-        * been derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
-        * specification, and will not have a simple relation to a 0.0.X id.
+        * The 20-byte EVM address of the contract to call. 
+        * 
+        * Every contract has an EVM address determined by its <tt>shard.realm.num</tt> id.
+        * This address is as follows:
+        *   <ol>
+        *     <li>The first 4 bytes are the big-endian representation of the shard.</li>
+        *     <li>The next 8 bytes are the big-endian representation of the realm.</li>
+        *     <li>The final 8 bytes are the big-endian representation of the number.</li>
+        *   </ol>  
+        * 
+        * Contracts created via CREATE2 have an additional, primary address that is derived 
+        * from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> specification, 
+        * and does not have a simple relation to a <tt>shard.realm.num</tt> id.
         */
         bytes evm_address = 4;
     }

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -85,7 +85,6 @@ message AccountID {
      * be populated.
      */
     oneof account {
-
         /**
          * A non-negative account number unique within its realm
          */
@@ -105,7 +104,6 @@ message AccountID {
          */
         bytes alias = 4;
     }
-
 }
 
 /**
@@ -142,10 +140,20 @@ message ContractID {
      */
     int64 realmNum = 2;
 
-    /**
-     * A nonnegative number unique within its realm
-     */
-    int64 contractNum = 3;
+    oneof contract {
+        /**
+        * A nonnegative number unique within its realm
+        */
+        int64 contractNum = 3;
+
+        /**
+        * The 20-byte EVM address of the contract to call. Note that if the 
+        * target contract was created via CREATE2, its address will have 
+        * been derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
+        * specification, and will not have a simple relation to a 0.0.X id.
+        */
+        bytes evm_address = 4;
+    }
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -157,9 +157,12 @@ message ContractID {
         *     <li>The final 8 bytes are the big-endian representation of the number.</li>
         *   </ol>  
         * 
-        * Contracts created via CREATE2 have an additional, primary address that is derived 
-        * from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> specification, 
-        * and does not have a simple relation to a <tt>shard.realm.num</tt> id.
+        * Contracts created via CREATE2 have an <b>additional, primary address</b> that is 
+        * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> 
+        * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id. 
+        * 
+        * (Please do note that CREATE2 contracts can also be referenced by the three-part 
+        * EVM address described above.)
         */
         bytes evm_address = 4;
     }

--- a/services/contract_call.proto
+++ b/services/contract_call.proto
@@ -50,7 +50,11 @@ message ContractCallTransactionBody {
         ContractID contractID = 1;
 
         /**
-        * The 20-byte Solidity address of the contract to call
+        * The 20-byte Solidity address of the contract to call. Note 
+        * that if the target contract was created via CREATE2, its 
+        * address will have been derived from the 
+        * <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
+        * specification, and will not have a simple relation to a 0.0.X id.
         */
         bytes solidity_address = 5;
     }

--- a/services/contract_call.proto
+++ b/services/contract_call.proto
@@ -43,21 +43,7 @@ message ContractCallTransactionBody {
     /**
      * The contract to call
      */
-    oneof contract {
-        /**
-        * The <shard>.<realm>.<num> identifier of the contract to call
-        */
-        ContractID contractID = 1;
-
-        /**
-        * The 20-byte Solidity address of the contract to call. Note 
-        * that if the target contract was created via CREATE2, its 
-        * address will have been derived from the 
-        * <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
-        * specification, and will not have a simple relation to a 0.0.X id.
-        */
-        bytes solidity_address = 5;
-    }
+    ContractID contractID = 1;
 
     /**
      * the maximum amount of gas to use for the call

--- a/services/contract_call.proto
+++ b/services/contract_call.proto
@@ -41,9 +41,19 @@ import "basic_types.proto";
  */
 message ContractCallTransactionBody {
     /**
-     * the contract instance to call, in the format used in transactions
+     * The contract to call
      */
-    ContractID contractID = 1;
+    oneof contract {
+        /**
+        * The <shard>.<realm>.<num> identifier of the contract to call
+        */
+        ContractID contractID = 1;
+
+        /**
+        * The 20-byte Solidity address of the contract to call
+        */
+        bytes solidity_address = 5;
+    }
 
     /**
      * the maximum amount of gas to use for the call

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -104,10 +104,25 @@ message ContractFunctionResult {
     repeated ContractID createdContractIDs = 7 [deprecated=true];
 
     /**
-     * The new contract's EVM address. Only populated after release 0.23, where each
-     * created contract will have its own record. (This is an important point--the 
-     * field is not <tt>repeated</tt> because there will be a separate child record 
-     * for each created contract.)
+     * The new contract's 20-byte EVM address. Only populated after release 0.23, 
+     * where each created contract will have its own record. (This is an important 
+     * point--the field is not <tt>repeated</tt> because there will be a separate 
+     * child record for each created contract.)
+     * 
+     * Every contract has an EVM address determined by its <tt>shard.realm.num</tt> id.
+     * This address is as follows:
+     *   <ol>
+     *     <li>The first 4 bytes are the big-endian representation of the shard.</li>
+     *     <li>The next 8 bytes are the big-endian representation of the realm.</li>
+     *     <li>The final 8 bytes are the big-endian representation of the number.</li>
+     *   </ol>  
+     * 
+     * Contracts created via CREATE2 have an <b>additional, primary address</b> that is 
+     * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> 
+     * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id. 
+     * 
+     * (Please do note that CREATE2 contracts can also be referenced by the three-part 
+     * EVM address described above.)
      */
      bytes evm_address = 8;
 }

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -131,7 +131,11 @@ message ContractCallLocalQuery {
         ContractID contractID = 2;
 
         /**
-        * The 20-byte Solidity address of the contract to call
+        * The 20-byte Solidity address of the contract to call. Note 
+        * that if the target contract was created via CREATE2, its 
+        * address will have been derived from the 
+        * <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
+        * specification, and will not have a simple relation to a 0.0.X id.
         */
         bytes solidity_address = 6;
     }

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -102,6 +102,12 @@ message ContractFunctionResult {
      * and its Solidity address.)
      */
     repeated ContractID createdContractIDs = 7 [deprecated=true];
+
+    /**
+     * The new contract's Solidity address. Only populated after release 0.23, where 
+     * each created contract will have its own record.
+     */
+     bytes solidity_address = 8;
 }
 
 /**

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -104,8 +104,10 @@ message ContractFunctionResult {
     repeated ContractID createdContractIDs = 7 [deprecated=true];
 
     /**
-     * The new contract's EVM address. Only populated after release 0.23, where 
-     * each created contract will have its own record.
+     * The new contract's EVM address. Only populated after release 0.23, where each
+     * created contract will have its own record. (This is an important point--the 
+     * field is not <tt>repeated</tt> because there will be a separate child record 
+     * for each created contract.)
      */
      bytes evm_address = 8;
 }

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -97,17 +97,17 @@ message ContractFunctionResult {
      * 
      * The created ids will now _also_ be externalized through internal transaction 
      * records, where each record has its alias field populated with the new contract's 
-     * Solidity address. (This is needed for contracts created with CREATE2, since 
+     * EVM address. (This is needed for contracts created with CREATE2, since 
      * there is no longer a simple relationship between the new contract's 0.0.X id 
      * and its Solidity address.)
      */
     repeated ContractID createdContractIDs = 7 [deprecated=true];
 
     /**
-     * The new contract's Solidity address. Only populated after release 0.23, where 
+     * The new contract's EVM address. Only populated after release 0.23, where 
      * each created contract will have its own record.
      */
-     bytes solidity_address = 8;
+     bytes evm_address = 8;
 }
 
 /**
@@ -130,21 +130,7 @@ message ContractCallLocalQuery {
     /**
      * The contract to make a static call against
      */
-    oneof contract {
-        /**
-        * The <shard>.<realm>.<num> identifier of the contract to call
-        */
-        ContractID contractID = 2;
-
-        /**
-        * The 20-byte Solidity address of the contract to call. Note 
-        * that if the target contract was created via CREATE2, its 
-        * address will have been derived from the 
-        * <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
-        * specification, and will not have a simple relation to a 0.0.X id.
-        */
-        bytes solidity_address = 6;
-    }
+    ContractID contractID = 2;
 
     /**
      * The amount of gas to use for the call; all of the gas offered will be used and charged a corresponding fee

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -93,9 +93,15 @@ message ContractFunctionResult {
     repeated ContractLoginfo logInfo = 6;
 
     /**
-     * the list of smart contracts that were created by the function call
+     * [DEPRECATED] the list of smart contracts that were created by the function call.
+     * 
+     * The created ids will now _also_ be externalized through internal transaction 
+     * records, where each record has its alias field populated with the new contract's 
+     * Solidity address. (This is needed for contracts created with CREATE2, since 
+     * there is no longer a simple relationship between the new contract's 0.0.X id 
+     * and its Solidity address.)
      */
-    repeated ContractID createdContractIDs = 7;
+    repeated ContractID createdContractIDs = 7 [deprecated=true];
 }
 
 /**
@@ -116,9 +122,19 @@ message ContractCallLocalQuery {
     QueryHeader header = 1;
 
     /**
-     * the contract instance to call, in the format used in transactions
+     * The contract to make a static call against
      */
-    ContractID contractID = 2;
+    oneof contract {
+        /**
+        * The <shard>.<realm>.<num> identifier of the contract to call
+        */
+        ContractID contractID = 2;
+
+        /**
+        * The 20-byte Solidity address of the contract to call
+        */
+        bytes solidity_address = 6;
+    }
 
     /**
      * The amount of gas to use for the call; all of the gas offered will be used and charged a corresponding fee

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -120,9 +120,6 @@ message TransactionRecord {
     /**
      * In the record of an internal CryptoCreate transaction triggered by a user 
      * transaction with a (previously unused) alias, the new account's alias. 
-     * 
-     * In the record of an internal ContractCreate transaction triggered by a user
-     * transaction, the new contract's Solidity address.
      */
      bytes alias = 16;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -125,10 +125,4 @@ message TransactionRecord {
      * transaction, the new contract's Solidity address.
      */
      bytes alias = 16;
-
-    /**
-     * In the record of an ContractCreate transaction (whether an internal transaction
-     * or a user-submitted transaction), the new contract's Solidity address.
-     */
-     bytes solidity_address = 17;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -120,6 +120,9 @@ message TransactionRecord {
     /**
      * In the record of an internal CryptoCreate transaction triggered by a user 
      * transaction with a (previously unused) alias, the new account's alias. 
+     * 
+     * In the record of an internal ContractCreate transaction triggered by a user
+     * transaction, the new contract's Solidity address.
      */
      bytes alias = 16;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -125,4 +125,10 @@ message TransactionRecord {
      * transaction, the new contract's Solidity address.
      */
      bytes alias = 16;
+
+    /**
+     * In the record of an ContractCreate transaction (whether an internal transaction
+     * or a user-submitted transaction), the new contract's Solidity address.
+     */
+     bytes solidity_address = 17;
 }


### PR DESCRIPTION
**Description**:
Prepares for `CREATE2` implementation.
1. Allows HAPI clients to use a `ContractID` to target a contract either by its number **or** its EVM address.
2. Deprecates the `ContractFunctionResult#createdContractIDs` field, which will be superseded by `ContractID`s externalized in the record stream via "child transactions".
3. Adds a `bytes evm_address` to the `ContractFunctionResult`, to be populated in the record of each contract creation (whether top-level or internal).