### PR TITLE
Added messages for approval/allowance feature (HIP 336)

### DIFF
--- a/services/crypto_adjust_allowance.proto
+++ b/services/crypto_adjust_allowance.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Modify an existing hbar/token allowance for a spender. If an allowance for the spender
+ * does not currently exist, this transaction will behave like an allowance approval.
+ */
+message CryptoAdjustAllowanceTransactionBody {
+    /**
+     * The token that the allowance pertains to. If this field is omitted, the adjustment
+     * will be made against the spender's hbar allowance with the account owner.
+     */
+    TokenID token = 1;
+
+    /**
+     * The account ID of the spender of the hbar/token allowance.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The amount to adjust the current allowance balance by. If this value is negative
+     * the approved allowance will be decreased. The adjusted allowance balance cannot
+     * exceed the total supply of the token nor can it be negative.
+     */
+    int64 amount = 3;
+}

--- a/services/crypto_adjust_allowance.proto
+++ b/services/crypto_adjust_allowance.proto
@@ -28,13 +28,19 @@ option java_multiple_files = true;
 import "basic_types.proto";
 
 /**
- * Modify an existing hbar/token allowance for a spender. If an allowance for the spender
- * does not currently exist, this transaction will behave like an allowance approval.
+ * Modifies or creates the hbar/token allowance for a spender <b>relative to the payer account
+ * of this transaction</b>. 
+ *
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus the spender 
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>). 
+ * 
+ * <b>IMPORTANT</b>: If an allowance for the spender does not currently exist, this transaction 
+ * behaves like an allowance approval.
  */
 message CryptoAdjustAllowanceTransactionBody {
     /**
      * The token that the allowance pertains to. If this field is omitted, the adjustment
-     * will be made against the spender's hbar allowance with the account owner.
+     * will be made against the spender's hbar allowance with the payer account.
      */
     TokenID token = 1;
 

--- a/services/crypto_approve_allowance.proto
+++ b/services/crypto_approve_allowance.proto
@@ -28,9 +28,12 @@ option java_multiple_files = true;
 import "basic_types.proto";
 
 /**
- * Create a series of hbar/token approved allowances. Each allowance grants a spender the right
- * to transfer a pre-determined amount of the owner's hbar/token to any other account of their
- * choice.
+ * Creates one or more hbar/token approved allowances <b>relative to the payer account of this
+ * transaction</b>. Each allowance grants a spender the right to transfer a pre-determined 
+ * amount of the payer's hbar/token to any other account of the spender's choice. 
+ * 
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus each spender 
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>). 
  */
 message CryptoApproveAllowanceTransactionBody {
     message CryptoApproval {

--- a/services/crypto_approve_allowance.proto
+++ b/services/crypto_approve_allowance.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Create a series of hbar/token approved allowances. Each allowance grants a spender the right
+ * to transfer a pre-determined amount of the owner's hbar/token to any other account of their
+ * choice.
+ */
+message CryptoApproveAllowanceTransactionBody {
+    message CryptoApproval {
+        /**
+         * The account ID of the spender of the hbar allowance.
+         */
+        AccountID spender = 1;
+
+        /**
+         * The amount of the spender's allowance in tinybars.
+         */
+        int64 amount = 2;
+    }
+
+    message TokenApproval {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token allowance spender.
+         */
+        AccountID spender = 2;
+
+        oneof allowance {
+            /**
+             * The amount of the spender's token allowance.
+             */
+            int64 amount = 3;
+
+            /**
+             * If true, the spender has access to all of the account owner's NFT instances (currently
+             * owned and any in the future).
+             */
+            bool approvedForAll = 4;
+        }
+    }
+
+    /**
+     * List of hbar allowances approved by the account owner.
+     */
+    repeated CryptoApproval cryptoApproval = 1;
+
+    /**
+     * List of token (fungible or non-fungible) allowances approved by the account owner.
+     */
+    repeated TokenApproval tokenApproval = 2;
+}

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -69,7 +69,7 @@ message CryptoGetInfoResponse {
         /**
          * The current balance of the spender's allowance in tinybars.
          */
-        int64 allowance = 2;
+        int64 amount = 2;
     }
 
     message TokenAllowance {
@@ -86,7 +86,7 @@ message CryptoGetInfoResponse {
         /**
          * The current balance of the spender's token allowance.
          */
-        google.protobuf.Int64Value allowance = 3;
+        google.protobuf.Int64Value amount = 3;
 
         /**
          * The number of decimal places the token allowance value is divisible by.
@@ -97,7 +97,7 @@ message CryptoGetInfoResponse {
          * If true, the spender has access to all of the account owner's NFT instances (currently
          * owned and any in the future).
          */
-        google.protobuf.BoolValue approvedForAll = 5;
+        bool approvedForAll = 5;
     }
 
     message AccountInfo {
@@ -209,19 +209,14 @@ message CryptoGetInfoResponse {
         bytes ledger_id = 20;
 
         /**
-         * The total number of allowances created across hbar and tokens (fungible and non-fungible).
-         */
-        int32 totalAllowances = 21;
-
-        /**
          * All of the hbar allowances approved by the account owner.
          */
-        repeated CryptoAllowance allowances = 22;
+        repeated CryptoAllowance allowances = 21;
 
         /**
          * All of the token (fungible and non-fungible) allowances approved by the account owner.
          */
-        repeated TokenAllowance tokenAllowances = 23;
+        repeated TokenAllowance tokenAllowances = 22;
     }
 
     /**

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -6,7 +6,7 @@ package proto;
  * ‌
  * Hedera Network Services Protobuf
  * ​
- * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
  * ​
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
 import "crypto_add_live_hash.proto";
+import "google/protobuf/wrappers.proto";
 
 /**
  * Get all the information about an account, including the balance. This does not get the list of
@@ -59,6 +60,45 @@ message CryptoGetInfoResponse {
      */
     ResponseHeader header = 1;
 
+    message CryptoAllowance {
+        /**
+         * The account ID of the hbar allowance spender.
+         */
+        AccountID spender = 1;
+
+        /**
+         * The current balance of the spender's allowance in tinybars.
+         */
+        int64 allowance = 2;
+    }
+
+    message TokenAllowance {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token allowance spender.
+         */
+        AccountID spender = 2;
+
+        /**
+         * The current balance of the spender's token allowance.
+         */
+        google.protobuf.Int64Value allowance = 3;
+
+        /**
+         * The number of decimal places the token allowance value is divisible by.
+         */
+        int32 decimals = 4;
+
+        /**
+         * If true, the spender has access to all of the account owner's NFT instances (currently
+         * owned and any in the future).
+         */
+        google.protobuf.BoolValue approvedForAll = 5;
+    }
 
     message AccountInfo {
         /**
@@ -167,6 +207,21 @@ message CryptoGetInfoResponse {
          * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
          */
         bytes ledger_id = 20;
+
+        /**
+         * The total number of allowances created across hbar and tokens (fungible and non-fungible).
+         */
+        int32 totalAllowances = 21;
+
+        /**
+         * All of the hbar allowances approved by the account owner.
+         */
+        repeated CryptoAllowance allowances = 22;
+
+        /**
+         * All of the token (fungible and non-fungible) allowances approved by the account owner.
+         */
+        repeated TokenAllowance tokenAllowances = 23;
     }
 
     /**

--- a/services/crypto_service.proto
+++ b/services/crypto_service.proto
@@ -53,6 +53,16 @@ service CryptoService {
     rpc cryptoDelete (Transaction) returns (TransactionResponse);
 
     /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    rpc approveAllowances (Transaction) returns (TransactionResponse);
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    rpc adjustAllowance (Transaction) returns (TransactionResponse);
+
+    /**
      * (NOT CURRENTLY SUPPORTED) Adds a livehash
      */
     rpc addLiveHash (Transaction) returns (TransactionResponse);

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1148,4 +1148,9 @@ enum ResponseCodeEnum {
    * The transfer amount exceeds the current approved allowance for the spender account.
    */
   AMOUNT_EXCEEDS_ALLOWANCE = 289;
+
+  /**
+   * The payer account of an approveAllowances or adjustAllowance transaction is attempting to go beyond the maximum allowed number of allowances.
+   */
+  MAX_ALLOWANCES_EXCEEDED = 290;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1116,4 +1116,36 @@ enum ResponseCodeEnum {
    * type actually has.
    */
   UNEXPECTED_TOKEN_DECIMALS = 283;
+
+  /**
+   * An approved allowance specifies a spender account that is the same as the hbar/token
+   * owner account.
+   */
+  SPENDER_ACCOUNT_SAME_AS_OWNER = 284;
+
+  /**
+   * The establishment or adjustment of an approved allowance cause the token allowance
+   * to exceed the token maximum supply.
+   */
+  AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY = 285;
+
+  /**
+   * The specified amount for an approved allowance cannot be negative.
+   */
+  NEGATIVE_ALLOWANCE_AMOUNT = 286;
+
+  /**
+   * The approveForAll flag cannot be set for a fungible token.
+   */
+  CANNOT_APPROVE_FOR_ALL_FUNGIBLE_COMMON = 287;
+
+  /**
+   * The spender does not have an existing approved allowance with the hbar/token owner.
+   */
+  SPENDER_DOES_NOT_HAVE_ALLOWANCE = 288;
+
+  /**
+   * The transfer amount exceeds the current approved allowance for the spender account.
+   */
+  AMOUNT_EXCEEDS_ALLOWANCE = 289;
 }

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -37,6 +37,8 @@ import "crypto_create.proto";
 import "crypto_delete.proto";
 import "crypto_transfer.proto";
 import "crypto_update.proto";
+import "crypto_approve_allowance.proto";
+import "crypto_adjust_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -85,6 +87,9 @@ message SchedulableTransactionBody {
    */
   string memo = 2;
 
+  /**
+   * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+   */
   oneof data {
     /**
      * Calls a function of a contract instance
@@ -105,6 +110,16 @@ message SchedulableTransactionBody {
      * Delete contract and transfer remaining balance into specified account
      */
     ContractDeleteTransactionBody contractDeleteInstance = 6;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 37;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 38;
 
     /**
      * Create a new cryptocurrency account
@@ -240,6 +255,11 @@ message SchedulableTransactionBody {
      * Dissociate tokens from an account
      */
     TokenDissociateTransactionBody tokenDissociate = 33;
+
+    /**
+     * Updates a token's custom fee schedule
+     */
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 39;
 
     /**
      * Pauses the Token

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -40,6 +40,7 @@ import "crypto_delete_live_hash.proto";
 import "crypto_transfer.proto";
 import "crypto_update.proto";
 import "crypto_approve_allowance.proto";
+import "crypto_adjust_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -115,6 +116,9 @@ message TransactionBody {
    */
   string memo = 6;
 
+  /**
+   * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+   */
   oneof data {
     /**
      * Calls a function of a contract instance
@@ -140,6 +144,16 @@ message TransactionBody {
      * Attach a new livehash to an account
      */
     CryptoAddLiveHashTransactionBody cryptoAddLiveHash = 10;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 48;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 49;
 
     /**
      * Create a new cryptocurrency account
@@ -315,10 +329,5 @@ message TransactionBody {
      * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
      */
     ScheduleSignTransactionBody scheduleSign = 44;
-
-    /**
-     * Adds an approved allowance for spender to transfer owner's hbar.
-     */
-    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 45;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -39,6 +39,7 @@ import "crypto_delete.proto";
 import "crypto_delete_live_hash.proto";
 import "crypto_transfer.proto";
 import "crypto_update.proto";
+import "crypto_approve_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -314,5 +315,10 @@ message TransactionBody {
      * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
      */
     ScheduleSignTransactionBody scheduleSign = 44;
+
+    /**
+     * Adds an approved allowance for spender to transfer owner's hbar.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 45;
   }
 }


### PR DESCRIPTION
Signed-off-by: Albert Tam <albert.tam@hedera.com>

**Description**:
Modified CryptoGetInfoResponse to include hbar/token allowances approved by the account owner. Added CryptoApproveAllowanceTransactionBody and CryptoAdjustAllowanceTransactionBody messages for an account owner to establish new allowances and modify existing allowances respectively.

Changes made as outlined in HIP 336.

**Related issue(s)**:

Fixes #132

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
