### PR TITLE
Use `BytesValue` for result `evm_address` to make its potential absence explicit

### DIFF
--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -131,7 +131,7 @@ message ContractFunctionResult {
      * (Please do note that CREATE2 contracts can also be referenced by the three-part 
      * EVM address described above.)
      */
-     bytes evm_address = 9;
+     google.protobuf.BytesValue evm_address = 9;
 }
 
 /**


### PR DESCRIPTION
n/m