### PR TITLE
Address reviewer comments

### DIFF
--- a/services/crypto_adjust_allowance.proto
+++ b/services/crypto_adjust_allowance.proto
@@ -28,13 +28,19 @@ option java_multiple_files = true;
 import "basic_types.proto";
 
 /**
- * Modify an existing hbar/token allowance for a spender. If an allowance for the spender
- * does not currently exist, this transaction will behave like an allowance approval.
+ * Modifies or creates the hbar/token allowance for a spender <b>relative to the payer account
+ * of this transaction</b>. 
+ *
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus the spender 
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>). 
+ * 
+ * <b>IMPORTANT</b>: If an allowance for the spender does not currently exist, this transaction 
+ * behaves like an allowance approval.
  */
 message CryptoAdjustAllowanceTransactionBody {
     /**
      * The token that the allowance pertains to. If this field is omitted, the adjustment
-     * will be made against the spender's hbar allowance with the account owner.
+     * will be made against the spender's hbar allowance with the payer account.
      */
     TokenID token = 1;
 

--- a/services/crypto_approve_allowance.proto
+++ b/services/crypto_approve_allowance.proto
@@ -28,9 +28,12 @@ option java_multiple_files = true;
 import "basic_types.proto";
 
 /**
- * Create a series of hbar/token approved allowances. Each allowance grants a spender the right
- * to transfer a pre-determined amount of the owner's hbar/token to any other account of their
- * choice.
+ * Creates one or more hbar/token approved allowances <b>relative to the payer account of this
+ * transaction</b>. Each allowance grants a spender the right to transfer a pre-determined 
+ * amount of the payer's hbar/token to any other account of the spender's choice. 
+ * 
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus each spender 
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>). 
  */
 message CryptoApproveAllowanceTransactionBody {
     message CryptoApproval {

--- a/services/crypto_service.proto
+++ b/services/crypto_service.proto
@@ -53,6 +53,16 @@ service CryptoService {
     rpc cryptoDelete (Transaction) returns (TransactionResponse);
 
     /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    rpc approveAllowances (Transaction) returns (TransactionResponse);
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    rpc adjustAllowance (Transaction) returns (TransactionResponse);
+
+    /**
      * (NOT CURRENTLY SUPPORTED) Adds a livehash
      */
     rpc addLiveHash (Transaction) returns (TransactionResponse);

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -37,6 +37,8 @@ import "crypto_create.proto";
 import "crypto_delete.proto";
 import "crypto_transfer.proto";
 import "crypto_update.proto";
+import "crypto_approve_allowance.proto";
+import "crypto_adjust_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -255,5 +257,15 @@ message SchedulableTransactionBody {
      * Marks a schedule in the network's action queue as deleted, preventing it from executing
      */
     ScheduleDeleteTransactionBody scheduleDelete = 34;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 37;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 38;
   }
 }

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -267,5 +267,10 @@ message SchedulableTransactionBody {
      * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
      */
     CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 38;
+
+    /**
+     * Updates a token's custom fee schedule
+     */
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 39;
   }
 }

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -87,6 +87,9 @@ message SchedulableTransactionBody {
    */
   string memo = 2;
 
+  /**
+   * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+   */
   oneof data {
     /**
      * Calls a function of a contract instance
@@ -107,6 +110,16 @@ message SchedulableTransactionBody {
      * Delete contract and transfer remaining balance into specified account
      */
     ContractDeleteTransactionBody contractDeleteInstance = 6;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 37;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 38;
 
     /**
      * Create a new cryptocurrency account
@@ -244,6 +257,11 @@ message SchedulableTransactionBody {
     TokenDissociateTransactionBody tokenDissociate = 33;
 
     /**
+     * Updates a token's custom fee schedule
+     */
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 39;
+
+    /**
      * Pauses the Token
      */
     TokenPauseTransactionBody token_pause = 35;
@@ -257,20 +275,5 @@ message SchedulableTransactionBody {
      * Marks a schedule in the network's action queue as deleted, preventing it from executing
      */
     ScheduleDeleteTransactionBody scheduleDelete = 34;
-
-    /**
-     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
-     */
-    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 37;
-
-    /**
-     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
-     */
-    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 38;
-
-    /**
-     * Updates a token's custom fee schedule
-     */
-    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 39;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -40,6 +40,7 @@ import "crypto_delete_live_hash.proto";
 import "crypto_transfer.proto";
 import "crypto_update.proto";
 import "crypto_approve_allowance.proto";
+import "crypto_adjust_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -317,8 +318,13 @@ message TransactionBody {
     ScheduleSignTransactionBody scheduleSign = 44;
 
     /**
-     * Adds an approved allowance for spender to transfer owner's hbar.
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
      */
-    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 45;
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 48;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 49;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -116,6 +116,9 @@ message TransactionBody {
    */
   string memo = 6;
 
+  /**
+   * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+   */
   oneof data {
     /**
      * Calls a function of a contract instance
@@ -141,6 +144,16 @@ message TransactionBody {
      * Attach a new livehash to an account
      */
     CryptoAddLiveHashTransactionBody cryptoAddLiveHash = 10;
+
+    /**
+     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     */
+    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 48;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 49;
 
     /**
      * Create a new cryptocurrency account
@@ -316,15 +329,5 @@ message TransactionBody {
      * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
      */
     ScheduleSignTransactionBody scheduleSign = 44;
-
-    /**
-     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
-     */
-    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 48;
-
-    /**
-     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
-     */
-    CryptoAdjustAllowanceTransactionBody cryptoAdjustAllowance = 49;
   }
 }


### PR DESCRIPTION
**Description**:
- Add approve and adjust allowance bodies to the `TransactionBody` and `SchedulableTransactionBody` choices.
- Add approve/adjust transactions to the `CryptoService`.
- Clarify in comments that spender allowances are against _the payer account_ of the `approveAllowances` or `adjustAllowance` transaction.