### PR TITLE
Breakout approval allowance for NFTs

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1495,9 +1495,9 @@ message TokenAssociation {
 }
 
 /**
- * An approved allowance for hbar transfers for a spender.
+ * An approved allowance of hbar transfers for a spender.
  */
-message CryptoApproval {
+message CryptoAllowance {
     /**
      * The account ID of the spender of the hbar allowance.
      */
@@ -1510,9 +1510,36 @@ message CryptoApproval {
 }
 
 /**
- * An approved allowance for fungible token transfers for a spender.
+ * An approved allowance of non-fungible token transfers for a spender.
  */
-message TokenApproval {
+message NftAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The list of serial numbers that the spender is permitted to transfer.
+     */
+    repeated int64 serialNumbers = 3;
+
+    /**
+     * If true, the spender has access to all of the account owner's NFT instances (currently
+     * owned and any in the future). If this field is set to true the serialNumbers field
+     * should be empty.
+     */
+    google.protobuf.BoolValue approvedForAll = 4;
+}
+
+/**
+ * An approved allowance of fungible token transfers for a spender.
+ */
+message TokenAllowance {
     /**
      * The token that the allowance pertains to.
      */
@@ -1529,31 +1556,4 @@ message TokenApproval {
     int64 amount = 3;
 }
 
-/**
- * An approved allowance for non-fungible token transfers for a spender.
- */
-message NftApproval {
-    /**
-     * The token that the allowance pertains to.
-     */
-    TokenID tokenId = 1;
-
-    /**
-     * The account ID of the token allowance spender.
-     */
-    AccountID spender = 2;
-
-    oneof allowance {
-        /**
-         * The list of serial numbers that the spender is permitted to transfer.
-         */
-        repeated int64 serialNumbers = 3 [packed = true];
-
-        /**
-         * If true, the spender has access to all of the account owner's NFT instances (currently
-         * owned and any in the future).
-         */
-        bool approvedForAll = 4;
-    }
-}
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1493,3 +1493,67 @@ message TokenAssociation {
     TokenID token_id = 1;  // The token involved in the association
     AccountID account_id = 2; // The account involved in the association
 }
+
+/**
+ * An approved allowance for hbar transfers for a spender.
+ */
+message CryptoApproval {
+    /**
+     * The account ID of the spender of the hbar allowance.
+     */
+    AccountID spender = 1;
+
+    /**
+     * The amount of the spender's allowance in tinybars.
+     */
+    int64 amount = 2;
+}
+
+/**
+ * An approved allowance for fungible token transfers for a spender.
+ */
+message TokenApproval {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The amount of the spender's token allowance.
+     */
+    int64 amount = 3;
+}
+
+/**
+ * An approved allowance for non-fungible token transfers for a spender.
+ */
+message NftApproval {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    oneof allowance {
+        /**
+         * The list of serial numbers that the spender is permitted to transfer.
+         */
+        repeated int64 serialNumbers = 3 [packed = true];
+
+        /**
+         * If true, the spender has access to all of the account owner's NFT instances (currently
+         * owned and any in the future).
+         */
+        bool approvedForAll = 4;
+    }
+}
+

--- a/services/crypto_adjust_allowance.proto
+++ b/services/crypto_adjust_allowance.proto
@@ -49,15 +49,15 @@ message CryptoAdjustAllowanceTransactionBody {
     /**
      * List of hbar allowances approved by the account owner.
      */
-    repeated CryptoApproval cryptoApproval = 1;
+    repeated CryptoAllowance cryptoAllowances = 1;
 
     /**
-     * List of token (fungible or non-fungible) allowances approved by the account owner.
+     * List of non-fungible token allowances approved by the account owner.
      */
-    repeated TokenApproval tokenApproval = 2;
+    repeated NftAllowance nftAllowances = 2;
 
     /**
-     * List of token non-fungible allowances approved by the account owner.
+     * List of fungible token allowances approved by the account owner.
      */
-    repeated NftApproval nftApprovals = 3;
+    repeated TokenAllowance tokenAllowances = 3;
 }

--- a/services/crypto_adjust_allowance.proto
+++ b/services/crypto_adjust_allowance.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Modifies or creates an hbar/token allowance for a spender <b>relative to the payer account
+ * of this transaction</b>.
+ *
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus the spender
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>).
+ *
+ * If the allowance already exists, the hbar/token amount will be used to adjust the current
+ * allowance balance. If this value is negative the approved allowance will be decreased.
+ * The adjusted allowance balance cannot exceed the total supply of the token nor can it
+ * be negative.
+ *
+ * If the allowance does not exist, it will be created with the hbar/token amount being used
+ * as the allowance balance.
+ *
+ * <b>IMPORTANT</b>: If an allowance for the spender does not currently exist, this transaction
+ * behaves like an allowance approval.
+ */
+message CryptoAdjustAllowanceTransactionBody {
+    /**
+     * List of hbar allowances approved by the account owner.
+     */
+    repeated CryptoApproval cryptoApproval = 1;
+
+    /**
+     * List of token (fungible or non-fungible) allowances approved by the account owner.
+     */
+    repeated TokenApproval tokenApproval = 2;
+
+    /**
+     * List of token non-fungible allowances approved by the account owner.
+     */
+    repeated NftApproval nftApprovals = 3;
+}

--- a/services/crypto_approve_allowance.proto
+++ b/services/crypto_approve_allowance.proto
@@ -39,15 +39,15 @@ message CryptoApproveAllowanceTransactionBody {
     /**
      * List of hbar allowances approved by the account owner.
      */
-    repeated CryptoApproval cryptoApprovals = 1;
+    repeated CryptoAllowance cryptoAllowances = 1;
 
     /**
-     * List of token fungible allowances approved by the account owner.
+     * List of non-fungible token allowances approved by the account owner.
      */
-    repeated TokenApproval tokenApprovals = 2;
+    repeated NftAllowance nftAllowances = 2;
 
     /**
-     * List of token non-fungible allowances approved by the account owner.
+     * List of fungible token allowances approved by the account owner.
      */
-    repeated NftApproval nftApprovals = 3;
+    repeated TokenAllowance tokenAllowances = 3;
 }

--- a/services/crypto_approve_allowance.proto
+++ b/services/crypto_approve_allowance.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Creates one or more hbar/token approved allowances <b>relative to the payer account of this
+ * transaction</b>. Each allowance grants a spender the right to transfer a pre-determined 
+ * amount of the payer's hbar/token to any other account of the spender's choice. 
+ * 
+ * (So if account <tt>0.0.X</tt> pays for this transaction, then at consensus each spender 
+ * account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>).
+ */
+message CryptoApproveAllowanceTransactionBody {
+    /**
+     * List of hbar allowances approved by the account owner.
+     */
+    repeated CryptoApproval cryptoApprovals = 1;
+
+    /**
+     * List of token fungible allowances approved by the account owner.
+     */
+    repeated TokenApproval tokenApprovals = 2;
+
+    /**
+     * List of token non-fungible allowances approved by the account owner.
+     */
+    repeated NftApproval nftApprovals = 3;
+}

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -59,65 +59,6 @@ message CryptoGetInfoResponse {
      */
     ResponseHeader header = 1;
 
-    message CryptoAllowance {
-        /**
-         * The account ID of the hbar allowance spender.
-         */
-        AccountID spender = 1;
-
-        /**
-         * The current balance of the spender's allowance in tinybars.
-         */
-        int64 amount = 2;
-    }
-
-    message TokenAllowance {
-        /**
-         * The token that the allowance pertains to.
-         */
-        TokenID tokenId = 1;
-
-        /**
-         * The account ID of the token allowance spender.
-         */
-        AccountID spender = 2;
-
-        /**
-         * The current balance of the spender's token allowance.
-         */
-        int64 amount = 3;
-
-        /**
-         * The number of decimal places the token allowance value is divisible by.
-         */
-        int32 decimals = 4;
-    }
-
-    message NftAllowance {
-        /**
-         * The token that the allowance pertains to.
-         */
-        TokenID tokenId = 1;
-
-        /**
-         * The account ID of the token allowance spender.
-         */
-        AccountID spender = 2;
-
-        oneof allowance {
-            /**
-             * List of serial numbers that the spender is permitted to transfer.
-             */
-            repeated int64 serialNumbers = 3 [packed = true];
-
-            /**
-             * If true, the spender has access to all of the account owner's NFT instances (currently
-             * owned and any in the future).
-             */
-            bool approvedForAll = 4;
-        }
-    }
-
     message AccountInfo {
         /**
          * The account ID for which this information applies
@@ -229,17 +170,17 @@ message CryptoGetInfoResponse {
         /**
          * All of the hbar allowances approved by the account owner.
          */
-        repeated CryptoAllowance allowances = 21;
-
-        /**
-         * All of the fungible token allowances approved by the account owner.
-         */
-        repeated TokenAllowance token_allowances = 22;
+        repeated CryptoAllowance crypto_allowances = 21;
 
         /**
          * All of the non-fungible token allowances approved by the account owner.
          */
-        repeated NftAllowance nft_allowances = 23;
+        repeated NftAllowance nft_allowances = 22;
+
+        /**
+         * All of the fungible token allowances approved by the account owner.
+         */
+        repeated TokenAllowance token_allowances = 23;
     }
 
     /**

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -59,6 +59,64 @@ message CryptoGetInfoResponse {
      */
     ResponseHeader header = 1;
 
+    message CryptoAllowance {
+        /**
+         * The account ID of the hbar allowance spender.
+         */
+        AccountID spender = 1;
+
+        /**
+         * The current balance of the spender's allowance in tinybars.
+         */
+        int64 amount = 2;
+    }
+
+    message TokenAllowance {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token allowance spender.
+         */
+        AccountID spender = 2;
+
+        /**
+         * The current balance of the spender's token allowance.
+         */
+        int64 amount = 3;
+
+        /**
+         * The number of decimal places the token allowance value is divisible by.
+         */
+        int32 decimals = 4;
+    }
+
+    message NftAllowance {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token allowance spender.
+         */
+        AccountID spender = 2;
+
+        oneof allowance {
+            /**
+             * List of serial numbers that the spender is permitted to transfer.
+             */
+            repeated int64 serialNumbers = 3 [packed = true];
+
+            /**
+             * If true, the spender has access to all of the account owner's NFT instances (currently
+             * owned and any in the future).
+             */
+            bool approvedForAll = 4;
+        }
+    }
 
     message AccountInfo {
         /**
@@ -167,6 +225,21 @@ message CryptoGetInfoResponse {
          * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
          */
         bytes ledger_id = 20;
+
+        /**
+         * All of the hbar allowances approved by the account owner.
+         */
+        repeated CryptoAllowance allowances = 21;
+
+        /**
+         * All of the fungible token allowances approved by the account owner.
+         */
+        repeated TokenAllowance token_allowances = 22;
+
+        /**
+         * All of the non-fungible token allowances approved by the account owner.
+         */
+        repeated NftAllowance nft_allowances = 23;
     }
 
     /**

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1136,4 +1136,47 @@ enum ResponseCodeEnum {
    * The alias already set on an account cannot be updated using CryptoUpdate transaction.
    */
   ALIAS_IS_IMMUTABLE = 287;
+
+  /**
+   * An approved allowance specifies a spender account that is the same as the hbar/token
+   * owner account.
+   */
+  SPENDER_ACCOUNT_SAME_AS_OWNER = 288;
+
+  /**
+   * The establishment or adjustment of an approved allowance cause the token allowance
+   * to exceed the token maximum supply.
+   */
+  AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY = 289;
+
+  /**
+   * The specified amount for an approved allowance cannot be negative.
+   */
+  NEGATIVE_ALLOWANCE_AMOUNT = 290;
+
+  /**
+   * The approveForAll flag cannot be set for a fungible token.
+   */
+  CANNOT_APPROVE_FOR_ALL_FUNGIBLE_COMMON = 291;
+
+  /**
+   * The spender does not have an existing approved allowance with the hbar/token owner.
+   */
+  SPENDER_DOES_NOT_HAVE_ALLOWANCE = 292;
+
+  /**
+   * The transfer amount exceeds the current approved allowance for the spender account.
+   */
+  AMOUNT_EXCEEDS_ALLOWANCE = 293;
+
+  /**
+   * The payer account of an approveAllowances or adjustAllowance transaction is attempting
+   * to go beyond the maximum allowed number of allowances.
+   */
+  MAX_ALLOWANCES_EXCEEDED = 294;
+
+  /**
+   * No allowances have been specified in the approval/adjust transaction.
+   */
+  EMPTY_ALLOWANCES = 295;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -122,4 +122,16 @@ message TransactionRecord {
      * transaction with a (previously unused) alias, the new account's alias. 
      */
      bytes alias = 16;
+
+     /**
+      * The current balances of any adjusted crypto allowances as a result of this
+      * transaction.
+      */
+    repeated CryptoApproval cryptoAdjustments = 17;
+
+    /**
+     * The current balances of any adjusted token allowances as a result of this
+     * transaction.
+     */
+    repeated TokenApproval tokenAdjustments = 18;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -125,19 +125,19 @@ message TransactionRecord {
 
      /**
       * The current balances of any adjusted crypto allowances as a result of this
-      * transaction.
+      * transaction. This field will only be populated for CryptoAdjustAllowanceTransaction.
       */
-    repeated CryptoApproval crypto_adjustments = 17;
-
-    /**
-     * The current balances of any adjusted fungible token allowances as a result of this
-     * transaction.
-     */
-    repeated TokenApproval token_adjustments = 18;
+    repeated CryptoAllowance crypto_adjustments = 17;
 
     /**
      * The current balances of any adjusted non-fungible token allowances as a result of this
-     * transaction.
+     * transaction. This field will only be populated for CryptoAdjustAllowanceTransaction.
      */
-    repeated NftApproval nft_adjustments = 19;
+    repeated NftAllowance nft_adjustments = 18;
+
+    /**
+     * The current balances of any adjusted fungible token allowances as a result of this
+     * transaction. This field will only be populated for CryptoAdjustAllowanceTransaction.
+     */
+    repeated TokenAllowance token_adjustments = 19;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -127,11 +127,17 @@ message TransactionRecord {
       * The current balances of any adjusted crypto allowances as a result of this
       * transaction.
       */
-    repeated CryptoApproval cryptoAdjustments = 17;
+    repeated CryptoApproval crypto_adjustments = 17;
 
     /**
-     * The current balances of any adjusted token allowances as a result of this
+     * The current balances of any adjusted fungible token allowances as a result of this
      * transaction.
      */
-    repeated TokenApproval tokenAdjustments = 18;
+    repeated TokenApproval token_adjustments = 18;
+
+    /**
+     * The current balances of any adjusted non-fungible token allowances as a result of this
+     * transaction.
+     */
+    repeated NftApproval nft_adjustments = 19;
 }


### PR DESCRIPTION
**Description**:
Breakout NFT allowances from fungible tokens to allow for ERC721 compatibility. We were previously allowing x transfers of NFT instances when in fact we should be very explicit in the NFT transfers to allow since one NFT is not interchangeable for another.

Create NftAllowance nested message in CryptoGetInfoResponse to return NFT specific info.

Create NftApproval message to be used in CryptoApproveAllowanceTransactionBody, CryptoAdjustAllowanceTransactionBody and TransactionRecord.

**Related issue(s)**:

Fixes #132

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
