### PR TITLE
Added is_approval flags for transfers to indicate allowance checks should be done

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -229,6 +229,12 @@ message AccountAmount {
      * receives(positive)
      */
     sint64 amount = 2;
+
+    /**
+     * If true then the transfer is expected to be an approved allowance and the
+     * accountID is expected to be the owner. The default is false (omitted).
+     */
+    bool is_approval = 3;
 }
 
 /**
@@ -262,6 +268,12 @@ message NftTransfer {
      * The serial number of the NFT
      */
     int64 serialNumber = 3;
+
+    /**
+     * If true then the transfer is expected to be an approved allowance and the
+     * senderAccountID is expected to be the owner. The default is false (omitted).
+     */
+    bool is_approval = 4;
 }
 
 /**


### PR DESCRIPTION
**Description**:

The main problem we're trying to solve is how to differentiate regular transfers involving the spender + owner versus a transfer that uses an allowance. We need to make this determination with minimal use of expanding signatures during `handleTransaction`.

The agreed upon approach is to add `is_approval` fields to `AccountAmount` and `NftTransfer`. The presence of the flag indicates that:
- The `accountID` should be treated as the allowance owner
- A signature check of the owner is not necessary as long as an allowance for the caller is present

The same approach holds for the NFT case.

**Related issue(s)**:

Fixes #132

**Notes for reviewer**:

Positioning the flag at this level grants us the flexibility of having approved transfers intermingled with regular transfers in a single transaction. There is also the added benefit of multiple allowances being involved in a single transfer transaction (pull from 2 owners, deposit into a single recipient). If we were to have the flag at the top-level transaction, every transfer in the transaction would be assumed to involve an allowance (not to mention the same allowance).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
