### PR TITLE
Update README, mark FCOTMR queries permanently disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ from the _*.proto_ files in this repository:
 # Overview of services
 
 There are five primary service families, which inter-operate on entities 
-controlled by one (or more) Ed25519 keypairs:
+controlled by one (or more) Ed25519 or ECDSA(secp256k1) keypairs:
 1. The [cryptocurrency service](services/CryptoService.proto),
 for cryptocurrency accounts with transfers denominated 
-in [hBar (ℏ)](https://help.hedera.com/hc/en-us/articles/360000674317-What-are-the-official-HBAR-cryptocurrency-denominations-).
+in [hbar (ℏ)](https://help.hedera.com/hc/en-us/articles/360000674317-What-are-the-official-HBAR-cryptocurrency-denominations-).
 2. The [consensus service](services/ConsensusService.proto), for
 fast and unbiased ordering of opaque binary messages exchanged on 
 arbitrary topics.
@@ -33,11 +33,9 @@ privileged accounts to suspend network operations during a maintenance window.
 It is important to note that most network services are gated by fees which 
 must be paid in ℏ from a cryptocurrency account. The payer authorizes a
 fee by signing an appropriate transaction with a sufficient subset of the 
-Ed25519 key(s) associated to their account.
+cryptographic key(s) associated to their account.
 
 # Branching
-This repository uses a simple branching model with only two distinguished branches:
- 1. The head of `main` points to the latest protobufs blessed for deployment to mainnet. 
+This repository uses a simple branching model with only one distinguished branch;
+`main` points to the latest protobufs intended for the next deployment to mainnet. 
 Tags such as `v0.12.0` mark commits used for testnet and mainnet deploys.
- 2. The head of `develop` points to the latest candidate for the next tag in `main`. 
-Tags suffixed with `-alpha.x` mark commits used for previewnet deploys. 

--- a/services/token_service.proto
+++ b/services/token_service.proto
@@ -104,7 +104,7 @@ service TokenService {
     rpc getTokenInfo (Query) returns (Response);
 
     /**
-     * (DEPRECATED) Gets info on NFTs N through M on the list of NFTs associated with a given account
+     * (PERMANENTLY DISABLED) Please use Mirror Node APIs to query for account NFT ownership 
      */
     rpc getAccountNftInfos (Query) returns (Response) {
          option deprecated = true;
@@ -116,7 +116,7 @@ service TokenService {
     rpc getTokenNftInfo (Query) returns (Response);
 
     /**
-     * (DEPRECATED) Gets info on NFTs N through M on the list of NFTs associated with a given Token of type NON_FUNGIBLE
+     * (PERMANENTLY DISABLED) Please use Mirror Node APIs to query for NFT mint information
      */
     rpc getTokenNftInfos (Query) returns (Response) {
          option deprecated = true;


### PR DESCRIPTION
**Description**:
- Updates doc to show the deprecated [`getAccountNftInfos` and `getTokenNftInfos` queries](https://hashgraph.github.io/hedera-protobufs/#proto.TokenService) as now **permanently disabled**.
- Fixes some inaccuracies in _README_.