### PR TITLE
Add precompile call data to ContractFunctionResults

### DIFF
--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -132,6 +132,31 @@ message ContractFunctionResult {
      * EVM address described above.)
      */
      google.protobuf.BytesValue evm_address = 9;
+
+    /**
+     * The amount of gas that was used for this call. 
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    int64 gas = 10;
+
+    /**
+     * Number of tinybars sent (the function must be payable if this is nonzero).
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    int64 amount = 11;
+
+    /**
+     * The parameters passed into the contract call.
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    bytes functionParameters = 12;
+     
 }
 
 /**

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -134,7 +134,7 @@ message ContractFunctionResult {
      google.protobuf.BytesValue evm_address = 9;
 
     /**
-     * The amount of gas that was used for this call. 
+     * The amount of gas available for the call, aka the gasLimit. 
      *
      * This field should only be populated when the paired TransactionBody in the record stream is not a
      * ContractCreateTransactionBody or a ContractCallTransactionBody.     


### PR DESCRIPTION
**Description**:

Add precompiled call data for parameters, gas, and amount to the
ContractFunctionResults. These would be in the TransactionBody
if it was a normal call but the body for precompiles is a
different type,

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Related issue(s)**:

Fixes #157


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
