### PR TITLE
Add transaction body and inner messages for CryptoDeleteAllowance

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1109,14 +1109,19 @@ enum HederaFunctionality {
     TokenUnpause = 80;
 
     /**
-     * Approve allowance for a spender relative to the payer account
+     * Approve allowance for a spender relative to the owner account
      */
     CryptoApproveAllowance = 81;
 
     /**
-     * Adjust allowances for a spender relative to the payer account
+     * Adjust allowances for a spender relative to the owner account
      */
     CryptoAdjustAllowance = 82;
+
+    /**
+     * Deletes granted allowances on owner account
+     */
+    CryptoDeleteAllowance = 83;
 }
 
 /**

--- a/services/crypto_delete_allowance.proto
+++ b/services/crypto_delete_allowance.proto
@@ -30,7 +30,8 @@ import "basic_types.proto";
 /**
  * Deletes one or more hbar/token approved allowances from an owner's account. This operation
  * will remove the allowances granted to <b>all</b> spenders of an owner's hbar, a specific
- * fungible token and/or a specific non-fungible token serial number.
+ * fungible token and/or a specific non-fungible token serial number. Each owner account
+ * listed as wiping an allowance must sign the transaction.
  */
 message CryptoDeleteAllowanceTransactionBody {
     /**

--- a/services/crypto_delete_allowance.proto
+++ b/services/crypto_delete_allowance.proto
@@ -1,0 +1,86 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Deletes one or more hbar/token approved allowances from an owner's account. This operation
+ * will remove the allowances granted to <b>all</b> spenders of an owner's hbar, a specific
+ * fungible token and/or a specific non-fungible token serial number.
+ */
+message CryptoDeleteAllowanceTransactionBody {
+    message CryptoDeleteAllowance {
+        /**
+         * The account ID of the hbar owner (ie. the grantor of the allowance).
+         */
+        AccountID owner = 1;
+    }
+
+    message NftDeleteAllowance {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token owner (ie. the grantor of the allowance).
+         */
+        AccountID owner = 2;
+
+        /**
+         * The list of serial numbers to remove allowances from.
+         */
+        repeated int64 serialNumbers = 3;
+    }
+
+    message TokenDeleteAllowance {
+        /**
+         * The token that the allowance pertains to.
+         */
+        TokenID tokenId = 1;
+
+        /**
+         * The account ID of the token owner (ie. the grantor of the allowance).
+         */
+        AccountID owner = 2;
+    }
+
+    /**
+     * List of hbar allowances to remove.
+     */
+    repeated CryptoDeleteAllowance cryptoAllowances = 1;
+
+    /**
+     * List of non-fungible token allowances to remove.
+     */
+    repeated NftDeleteAllowance nftAllowances = 2;
+
+    /**
+     * List of fungible token allowances to remove.
+     */
+    repeated TokenDeleteAllowance tokenAllowances = 3;
+}

--- a/services/crypto_delete_allowance.proto
+++ b/services/crypto_delete_allowance.proto
@@ -33,54 +33,63 @@ import "basic_types.proto";
  * fungible token and/or a specific non-fungible token serial number.
  */
 message CryptoDeleteAllowanceTransactionBody {
-    message CryptoDeleteAllowance {
-        /**
-         * The account ID of the hbar owner (ie. the grantor of the allowance).
-         */
-        AccountID owner = 1;
-    }
-
-    message NftDeleteAllowance {
-        /**
-         * The token that the allowance pertains to.
-         */
-        TokenID tokenId = 1;
-
-        /**
-         * The account ID of the token owner (ie. the grantor of the allowance).
-         */
-        AccountID owner = 2;
-
-        /**
-         * The list of serial numbers to remove allowances from.
-         */
-        repeated int64 serialNumbers = 3;
-    }
-
-    message TokenDeleteAllowance {
-        /**
-         * The token that the allowance pertains to.
-         */
-        TokenID tokenId = 1;
-
-        /**
-         * The account ID of the token owner (ie. the grantor of the allowance).
-         */
-        AccountID owner = 2;
-    }
-
     /**
      * List of hbar allowances to remove.
      */
-    repeated CryptoDeleteAllowance cryptoAllowances = 1;
+    repeated CryptoWipeAllowance cryptoAllowances = 1;
 
     /**
      * List of non-fungible token allowances to remove.
      */
-    repeated NftDeleteAllowance nftAllowances = 2;
+    repeated NftWipeAllowance nftAllowances = 2;
 
     /**
      * List of fungible token allowances to remove.
      */
-    repeated TokenDeleteAllowance tokenAllowances = 3;
+    repeated TokenWipeAllowance tokenAllowances = 3;
+}
+
+/**
+ * Hbar allowances to be removed on an owner account
+ */
+message CryptoWipeAllowance {
+    /**
+     * The account ID of the hbar owner (ie. the grantor of the allowance).
+     */
+    AccountID owner = 1;
+}
+
+/**
+ * Nft allowances to be removed on an owner account
+ */
+message NftWipeAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token owner (ie. the grantor of the allowance).
+     */
+    AccountID owner = 2;
+
+    /**
+     * The list of serial numbers to remove allowances from.
+     */
+    repeated int64 serial_numbers = 3;
+}
+
+/**
+ * Token allowances to be removed on an owner account
+ */
+message TokenWipeAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token owner (ie. the grantor of the allowance).
+     */
+    AccountID owner = 2;
 }

--- a/services/crypto_service.proto
+++ b/services/crypto_service.proto
@@ -63,6 +63,11 @@ service CryptoService {
     rpc adjustAllowance (Transaction) returns (TransactionResponse);
 
     /**
+     * Deletes the approved hbar or token allowance on an owner account.
+     */
+    rpc deleteAllowance (Transaction) returns (TransactionResponse);
+
+    /**
      * (NOT CURRENTLY SUPPORTED) Adds a livehash
      */
     rpc addLiveHash (Transaction) returns (TransactionResponse);

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1210,4 +1210,9 @@ enum ResponseCodeEnum {
    * The account id specified as the spender is invalid or does not exist.
    */
   INVALID_ALLOWANCE_SPENDER_ID = 301;
+
+  /**
+   * If the CryptoDeleteAllowance transaction has repeated crypto or token or Nft allowances to delete.
+   */
+  REPEATED_ALLOWANCES_TO_DELETE = 302;
 }

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -39,6 +39,7 @@ import "crypto_transfer.proto";
 import "crypto_update.proto";
 import "crypto_approve_allowance.proto";
 import "crypto_adjust_allowance.proto";
+import "crypto_delete_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -121,6 +122,11 @@ message SchedulableTransactionBody {
      * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
      */
     CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 38;
+
+    /**
+     * Deletes one or more approved hbar or token allowances from an owner's account
+     */
+    CryptoDeleteAllowanceTransactionBody cryptoDeleteAllowance = 40;
 
     /**
      * Create a new cryptocurrency account

--- a/services/token_get_nft_info.proto
+++ b/services/token_get_nft_info.proto
@@ -90,6 +90,11 @@ message TokenNftInfo {
      * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
      */
     bytes ledger_id = 5;
+
+    /**
+     * If an allowance is granted for the NFT, its corresponding spender account
+     */
+    AccountID spender_id = 6;
 }
 
 /**

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -41,6 +41,7 @@ import "crypto_transfer.proto";
 import "crypto_update.proto";
 import "crypto_approve_allowance.proto";
 import "crypto_adjust_allowance.proto";
+import "crypto_delete_allowance.proto";
 
 import "file_append.proto";
 import "file_create.proto";
@@ -154,6 +155,11 @@ message TransactionBody {
      * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
      */
     CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 49;
+
+    /**
+     * Deletes one or more approved hbar or token allowances from an owner's account
+     */
+    CryptoDeleteAllowanceTransactionBody cryptoDeleteAllowance = 50;
 
     /**
      * Create a new cryptocurrency account


### PR DESCRIPTION
Signed-off-by: Albert Tam <albert.tam@hedera.com>

**Description**:
Added CryptoDeleteAllowanceTransactionBody and inner messages xDeleteAllowance (crypto, nft, token) for new HAPI operation CryptoDeleteAllowance.

Operation allows callers to delete all allowances without specifying the spender.

**Related issue(s)**:

Fixes #164

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
