### PR TITLE
Remove serials in GetAccountInfo for NFT allowances

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1571,6 +1571,12 @@ message NftAllowance {
      * should be empty.
      */
     google.protobuf.BoolValue approvedForAll = 5;
+
+    /**
+     * The account ID of the spender who is granted approvedForAll allowance and granting
+     * approval on an NFT serial to another spender.
+     */
+    AccountID delegatingSpender = 6;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1614,7 +1614,7 @@ message GrantedCryptoAllowance {
 }
 
 /**
- * A granted allowance of non-fungible token transfers for a spender relative to the owner account.
+ * A granted allowance for all the NFTs of a token for a spender relative to the owner account.
  */
 message GrantedNftAllowance {
     /**
@@ -1623,21 +1623,9 @@ message GrantedNftAllowance {
     TokenID token_id = 1;
 
     /**
-     * The account ID of the token allowance spender.
+     * The account ID of the spender that has been granted access to all NFTs of the owner
      */
     AccountID spender = 2;
-
-    /**
-     * The list of serial numbers that the spender is permitted to transfer.
-     */
-    repeated int64 serial_numbers = 3;
-
-    /**
-     * If true, the spender has access to all of the account owner's NFT instances (currently
-     * owned and any in the future). If this field is set to true the serialNumbers field
-     * should be empty.
-     */
-    bool approved_for_all = 4;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1563,20 +1563,20 @@ message NftAllowance {
     /**
      * The list of serial numbers that the spender is permitted to transfer.
      */
-    repeated int64 serialNumbers = 4;
+    repeated int64 serial_numbers = 4;
 
     /**
      * If true, the spender has access to all of the account owner's NFT instances (currently
      * owned and any in the future). If this field is set to true the serialNumbers field
      * should be empty.
      */
-    google.protobuf.BoolValue approvedForAll = 5;
+    google.protobuf.BoolValue approved_for_all = 5;
 
     /**
      * The account ID of the spender who is granted approvedForAll allowance and granting
      * approval on an NFT serial to another spender.
      */
-    AccountID delegatingSpender = 6;
+    AccountID delegating_spender = 6;
 }
 
 /**

--- a/services/crypto_delete_allowance.proto
+++ b/services/crypto_delete_allowance.proto
@@ -37,23 +37,23 @@ message CryptoDeleteAllowanceTransactionBody {
     /**
      * List of hbar allowances to remove.
      */
-    repeated CryptoWipeAllowance cryptoAllowances = 1;
+    repeated CryptoRemoveAllowance cryptoAllowances = 1;
 
     /**
      * List of non-fungible token allowances to remove.
      */
-    repeated NftWipeAllowance nftAllowances = 2;
+    repeated NftRemoveAllowance nftAllowances = 2;
 
     /**
      * List of fungible token allowances to remove.
      */
-    repeated TokenWipeAllowance tokenAllowances = 3;
+    repeated TokenRemoveAllowance tokenAllowances = 3;
 }
 
 /**
  * Hbar allowances to be removed on an owner account
  */
-message CryptoWipeAllowance {
+message CryptoRemoveAllowance {
     /**
      * The account ID of the hbar owner (ie. the grantor of the allowance).
      */
@@ -63,7 +63,7 @@ message CryptoWipeAllowance {
 /**
  * Nft allowances to be removed on an owner account
  */
-message NftWipeAllowance {
+message NftRemoveAllowance {
     /**
      * The token that the allowance pertains to.
      */
@@ -83,7 +83,7 @@ message NftWipeAllowance {
 /**
  * Token allowances to be removed on an owner account
  */
-message TokenWipeAllowance {
+message TokenRemoveAllowance {
     /**
      * The token that the allowance pertains to.
      */

--- a/services/crypto_service.proto
+++ b/services/crypto_service.proto
@@ -60,12 +60,12 @@ service CryptoService {
     /**
      * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
      */
-    rpc adjustAllowance (Transaction) returns (TransactionResponse);
+    rpc adjustAllowances (Transaction) returns (TransactionResponse);
 
     /**
      * Deletes the approved hbar or token allowance on an owner account.
      */
-    rpc deleteAllowance (Transaction) returns (TransactionResponse);
+    rpc deleteAllowances (Transaction) returns (TransactionResponse);
 
     /**
      * (NOT CURRENTLY SUPPORTED) Adds a livehash

--- a/services/crypto_service.proto
+++ b/services/crypto_service.proto
@@ -58,12 +58,12 @@ service CryptoService {
     rpc approveAllowances (Transaction) returns (TransactionResponse);
 
     /**
-     * Adjusts the approved allowance for a spender to transfer the paying account's hbar or tokens.
+     * Adjusts the approved allowances for a spender to transfer the paying account's hbar or tokens.
      */
     rpc adjustAllowances (Transaction) returns (TransactionResponse);
 
     /**
-     * Deletes the approved hbar or token allowance on an owner account.
+     * Deletes the approved hbar or token allowances on an owner account.
      */
     rpc deleteAllowances (Transaction) returns (TransactionResponse);
 

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1215,4 +1215,20 @@ enum ResponseCodeEnum {
    * If the CryptoDeleteAllowance transaction has repeated crypto or token or Nft allowances to delete.
    */
   REPEATED_ALLOWANCES_TO_DELETE = 302;
+
+  /**
+   * If the account Id specified as the delegating spender is invalid or does not exist.
+   */
+  INVALID_DELEGATING_SPENDER = 303;
+
+  /**
+   * The delegating Spender cannot grant approveForAll allowance on a NFT token type for another spender.
+   */
+  DELEGATING_SPENDER_CANNOT_GRANT_APPROVE_FOR_ALL = 304;
+
+  /**
+   * The delegating Spender cannot grant allowance on a NFT serial for another spender as it doesnt not have approveForAll
+   * granted on token-owner.
+   */
+  DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL = 305;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -130,14 +130,8 @@ message TransactionRecord {
     repeated CryptoAllowance crypto_adjustments = 17;
 
     /**
-     * The current balances of any adjusted non-fungible token allowances as a result of this
-     * transaction. This field will only be populated for CryptoAdjustAllowanceTransaction.
-     */
-    repeated NftAllowance nft_adjustments = 18;
-
-    /**
      * The current balances of any adjusted fungible token allowances as a result of this
      * transaction. This field will only be populated for CryptoAdjustAllowanceTransaction.
      */
-    repeated TokenAllowance token_adjustments = 19;
+    repeated TokenAllowance token_adjustments = 18;
 }


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

- Since there is no more a map in account state with list of serials for NFTs and is moved to `MerkleUniqueToken` , removing it from the getAccountInfo `GrantedNftAllowance`