### PR TITLE
Add response codes for unsuccessful contract account delete attempts

### DIFF
--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1231,4 +1231,14 @@ enum ResponseCodeEnum {
    * granted on token-owner.
    */
   DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL = 305;
+
+  /**
+   * If using selfdestruct or ContractDelete targeting a contract that is a token treasury
+   */
+  CONTRACT_IS_TOKEN_TREASURY = 306;
+
+  /**
+   * If using selfdestruct or ContractDelete targeting a contract that holds non-zero NFT balance
+   */
+  CONTRACT_STILL_OWNS_NFTS = 307;
 }


### PR DESCRIPTION
**Description**:

This PR adds 2 response codes needed to handle deletion of contract accounts through self-destruct call or ContractDelete hapi tx when the contract account is used as token treasury or holds NFTs.

**Related issue(s)**:

Related to #3087

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
