### PR TITLE
Include fields needed for contract expiry and auto-association semantics

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -107,6 +107,16 @@ message AccountID {
 }
 
 /**
+ * A com.google.protobuf-style wrapper for an AccountID.
+ */
+message AccountIDValue {
+    /**
+     * If set, the id of a cryptocurrency account.
+     */
+    AccountID value = 1;
+}
+
+/**
  * The ID for a file 
  */
 message FileID {

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -103,17 +103,13 @@ message AccountID {
          * in that account, without creating anything, and with no creation fee being charged.
          */
         bytes alias = 4;
-    }
-}
 
-/**
- * A com.google.protobuf-style wrapper for an AccountID.
- */
-message AccountIDValue {
+    }
+
     /**
-     * If set, the id of a cryptocurrency account.
-     */
-    AccountID value = 1;
+     * If set in an *UpdateTransactionBody, clears the target account ID. Not usable outside an update transaction.
+    */
+    bool clear = 5;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -105,11 +105,6 @@ message AccountID {
         bytes alias = 4;
 
     }
-
-    /**
-     * If set in an *UpdateTransactionBody, clears the target account ID. Not usable outside an update transaction.
-    */
-    bool clear = 5;
 }
 
 /**

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -80,6 +80,9 @@ import "duration.proto";
  *    guide their decisions during a binding arbitration tribunal, convened to consider any changes
  *    to the smart contract in the future. The memo field can only be changed using the admin keys.
  *    If there are no admin keys, then it cannot be changed after the smart contract is created.
+ *
+ * <b>Signing requirements:</b> If an admin key is set, it must sign the transaction. If an 
+ * auto-renew account is set, its key must sign the transaction.
  */
 message ContractCreateTransactionBody {
 
@@ -161,4 +164,17 @@ message ContractCreateTransactionBody {
      * the memo that was submitted as part of the contract (max 100 bytes)
      */
     string memo = 13;
+
+    /**
+     * The maximum number of tokens that this contract can be automatically associated 
+     * with (i.e., receive air-drops from).
+     */
+    int32 max_automatic_token_associations = 14;
+
+    /**
+     * An account to charge for auto-renewal of this contract. If not set, or set to an 
+     * account with zero hbar balance, the contract's own hbar balance will be used to 
+     * cover auto-renewal fees.
+     */
+    AccountID auto_renew_account_id = 15;
 }

--- a/services/contract_delete.proto
+++ b/services/contract_delete.proto
@@ -54,4 +54,10 @@ message ContractDeleteTransactionBody {
          */
 	    ContractID transferContractID = 3;
     }
+
+    /**
+     * If set to true, means this is a "synthetic" system transaction being used to 
+     * alert mirror nodes that the contract is being permanently removed from the ledger.
+     */
+    bool permanent_removal = 4;
 }

--- a/services/contract_delete.proto
+++ b/services/contract_delete.proto
@@ -58,6 +58,10 @@ message ContractDeleteTransactionBody {
     /**
      * If set to true, means this is a "synthetic" system transaction being used to 
      * alert mirror nodes that the contract is being permanently removed from the ledger.
+     * <b>IMPORTANT:</b> User transactions cannot set this field to true, as permanent
+     * removal is always managed by the ledger itself. Any ContractDeleteTransactionBody
+     * submitted to HAPI with permanent_removal=true will be rejected with precheck status
+     * PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION.
      */
     bool permanent_removal = 4;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -109,7 +109,7 @@ message ContractUpdateTransactionBody {
 
     /**
      * If set, either gives the value of the new auto-renew account id for this contract; or if 
-     * set without any inner value, removes the existing auto-renew account of the contract.
+     * set with clear=true, removes the existing auto-renew account of the contract.
      */
-    AccountIDValue auto_renew_account_id = 12;
+    AccountID auto_renew_account_id = 12;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -39,13 +39,18 @@ import "google/protobuf/wrappers.proto";
  * MODIFYING_IMMUTABLE_CONTRACT.
  * 
  * --- Signing Requirements ---
- * 1. Whether or not a contract has an admin Key, its expiry can be extended with only the
+ * 1. Whether or not a contract has an admin key, its expiry can be extended with only the
  *    transaction payer's signature.
  * 2. Updating any other field of a mutable contract requires the admin key's signature.
  * 3. If the update transaction includes a new admin key, this new key must also sign <b>unless</b>
  *    it is exactly an empty <tt>KeyList</tt>. This special sentinel key removes the existing admin
  *    key and causes the contract to become immutable. (Other <tt>Key</tt> structures without a
  *    constituent <tt>Ed25519</tt> key will be rejected with <tt>INVALID_ADMIN_KEY</tt>.)
+ * 4. If the update transaction sets the AccountIDValue auto_renew_account_id wrapper field, 
+ *    then there are two possibilities. First, if the wrapper is set but does not contain an value,
+ *    the contract's auto-renew account is <b>removed</b> and no additional signature is required. 
+ *    Second, if the wrapper is set with new auto-renew account id, then the key of that account 
+ *    must sign.
  */
 message ContractUpdateTransactionBody {
     /**
@@ -95,5 +100,16 @@ message ContractUpdateTransactionBody {
        */
       google.protobuf.StringValue memoWrapper = 10;
     }
-}
 
+    /**
+     * If set, the new maximum number of tokens that this contract can be 
+     * automatically associated with (i.e., receive air-drops from).
+     */
+    google.protobuf.Int32Value max_automatic_token_associations = 11;
+
+    /**
+     * If set, either gives the value of the new auto-renew account id for this contract; or if 
+     * set without any inner value, removes the existing auto-renew account of the contract.
+     */
+    AccountIDValue auto_renew_account_id = 12;
+}

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -108,8 +108,8 @@ message ContractUpdateTransactionBody {
     google.protobuf.Int32Value max_automatic_token_associations = 11;
 
     /**
-     * If set, either gives the value of the new auto-renew account id for this contract; or if 
-     * set with clear=true, removes the existing auto-renew account of the contract.
+     * If set to the sentinel <tt>0.0.0</tt> AccountID, this field removes the contract's auto-renew 
+     * account. Otherwise it updates the contract's auto-renew account to the referenced account.
      */
     AccountID auto_renew_account_id = 12;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -49,7 +49,7 @@ import "google/protobuf/wrappers.proto";
  * 4. If the update transaction sets the AccountIDValue auto_renew_account_id wrapper field, 
  *    then there are two possibilities. First, if the wrapper is set but does not contain an value,
  *    the contract's auto-renew account is <b>removed</b> and no additional signature is required. 
- *    Second, if the wrapper is set with new auto-renew account id, then the key of that account 
+ *    Second, if the wrapper is set with a new auto-renew account ID, then the key of that account 
  *    must sign.
  */
 message ContractUpdateTransactionBody {

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -46,11 +46,8 @@ import "google/protobuf/wrappers.proto";
  *    it is exactly an empty <tt>KeyList</tt>. This special sentinel key removes the existing admin
  *    key and causes the contract to become immutable. (Other <tt>Key</tt> structures without a
  *    constituent <tt>Ed25519</tt> key will be rejected with <tt>INVALID_ADMIN_KEY</tt>.)
- * 4. If the update transaction sets the AccountIDValue auto_renew_account_id wrapper field, 
- *    then there are two possibilities. First, if the wrapper is set but does not contain an value,
- *    the contract's auto-renew account is <b>removed</b> and no additional signature is required. 
- *    Second, if the wrapper is set with a new auto-renew account ID, then the key of that account 
- *    must sign.
+ * 4. If the update transaction sets the AccountID auto_renew_account_id wrapper field to anything
+ *    other than the sentinel <tt>0.0.0</tt> value, then the key of the referenced account must sign.
  */
 message ContractUpdateTransactionBody {
     /**

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1298,4 +1298,9 @@ enum ResponseCodeEnum {
    * no auto-renew account.
    */
   CONTRACT_HAS_NO_AUTO_RENEW_ACCOUNT = 318;
+
+  /**
+   * A delete transaction submitted via HAPI set permanent_removal=true 
+   */
+  PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1276,4 +1276,26 @@ enum ResponseCodeEnum {
    * A schedule being signed or deleted has passed it's expiration date and is pending execution if needed and then expiration.
    */
   SCHEDULE_PENDING_EXPIRATION = 314;
+
+  /**
+   * A selfdestruct or ContractDelete targeted a contract that is a token treasury.
+   */
+  CONTRACT_IS_TOKEN_TREASURY = 315;
+
+  /**
+   * A selfdestruct or ContractDelete targeted a contract with non-zero token balances.
+   */
+  CONTRACT_HAS_NON_ZERO_TOKEN_BALANCES = 316;  
+
+  /**
+   * A contract referenced by a transaction is "detached"; that is, expired and lacking any
+   * hbar funds for auto-renewal payment---but still within its post-expiry grace period.
+   */
+  CONTRACT_EXPIRED_AND_PENDING_REMOVAL = 317;
+
+  /**
+   * A ContractUpdate requested removal of a contract's auto-renew account, but that contract has  
+   * no auto-renew account.
+   */
+  CONTRACT_HAS_NO_AUTO_RENEW_ACCOUNT = 318;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1303,10 +1303,4 @@ enum ResponseCodeEnum {
    * A delete transaction submitted via HAPI set permanent_removal=true 
    */
   PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
-
-  /**
-   * An AccountID with clear=true only makes sense in an update transaction (for example,
-   * when removing the auto-renew account from a contract)
-   */
-  ACCOUNT_ID_CAN_ONLY_BE_CLEARED_IN_UPDATE_TRANSACTION = 320;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1303,4 +1303,10 @@ enum ResponseCodeEnum {
    * A delete transaction submitted via HAPI set permanent_removal=true 
    */
   PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
+
+  /**
+   * An AccountID with clear=true only makes sense in an update transaction (for example,
+   * when removing the auto-renew account from a contract)
+   */
+  ACCOUNT_ID_CAN_ONLY_BE_CLEARED_IN_UPDATE_TRANSACTION = 320;
 }


### PR DESCRIPTION
**Related issues**:
 - Closes #176 
 - Closes #177 
 
**Description**:
- Adds fields to `ContractCreate-` and `ContractUpdateTransactionBody` messages to allow creating and updating contracts with both an auto-renew account and auto-association slots.
- Adds a few response codes needed to give contract-specific failure statuses.
- Adds a `bool permanent_removal` flag to `ContractDeleteTransactionBody` for use in a synthetic removal record.