### PR TITLE
fix(#183): add schedule create sub fee type, clairify some docs

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -440,6 +440,11 @@ enum SubType {
      * token with a custom fee schedule
      */
     TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES = 4;
+
+    /**
+     * The resource prices are scoped to a ScheduleCreate containing a ContractCall.
+     */
+    SCHEDULE_CREATE_CONTRACT_CALL = 5;
 }
 
 /**

--- a/services/schedule_create.proto
+++ b/services/schedule_create.proto
@@ -61,7 +61,8 @@ import "schedulable_transaction_body.proto";
  * the payer of the originating <tt>ScheduleCreate</tt>.  
  * 
  * Two <tt>ScheduleCreate</tt> transactions are <i>identical</i> if they are equal in all their
- * fields other than <tt>payerAccountID</tt>.  (Here "equal" should be understood in the sense of
+ * fields other than <tt>payerAccountID</tt>.  (For the <tt>scheduledTransactionBody</tt> field,
+ * "equal" should be understood in the sense of
  * gRPC object equality in the network software runtime. In particular, a gRPC object with <a
  * href="https://developers.google.com/protocol-buffers/docs/proto3#unknowns">unknown fields</a> is
  * not equal to a gRPC object without unknown fields, even if they agree on all known fields.) 


### PR DESCRIPTION

**Description**:
Add a sub type for schedule create with a contract call fees, clarify docs on schedule create

**Related issue(s)**:

Fixes #

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
