### PR TITLE
Renumber and Reorder Ethereum entries

### DIFF
--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -103,7 +103,7 @@ message ContractCreateTransactionBody {
          * The bytes of the smart contract initcode. This is only useful if the smart contract init
          * is less than the hedera transaction limit. In those cases fileID must be used.
          */
-        bytes initcode = 7;
+        bytes initcode = 16;
     }
 
     /**

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -143,6 +143,11 @@ message TransactionBody {
     ContractDeleteTransactionBody contractDeleteInstance = 22;
 
     /**
+     * An Ethereum encoded transaction.
+     */
+    EthereumTransactionBody ethereumTransaction = 50;
+
+    /**
      * Attach a new livehash to an account
      */
     CryptoAddLiveHashTransactionBody cryptoAddLiveHash = 10;
@@ -181,11 +186,6 @@ message TransactionBody {
      * Modify information such as the expiration date for an account
      */
     CryptoUpdateTransactionBody cryptoUpdateAccount = 15;
-
-    /**
-     * An Ethereum encoded transaction.
-     */
-    EthereumTransactionBody ethereumTransaction = 51;
 
     /**
      * Add bytes to the end of the contents of a file


### PR DESCRIPTION
Renumber and move `TransactionBody.ethereumTransaction`. - remove gap at 50
Renumber `ContractCreateTransactionBody.initcode` - preserver historical gap at 7

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>
