### PR TITLE
Additional changes for smart contract expiry

### DIFF
--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -128,6 +128,11 @@ message ContractGetInfoResponse {
          * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
          */
         bytes ledger_id = 12;
+        /**
+         * An account to charge for auto-renewal of this contract. If not set, or set to an account with zero hbar
+         * balance, the contract's own hbar balance will be used to cover auto-renewal fees.
+         */
+        AccountID auto_renew_account_id = 13;
     }
 
     /**

--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -128,6 +128,7 @@ message ContractGetInfoResponse {
          * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
          */
         bytes ledger_id = 12;
+
         /**
          * ID of the an account to charge for auto-renewal of this contract. If not set, or set to an account with zero hbar
          * balance, the contract's own hbar balance will be used to cover auto-renewal fees.

--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -129,7 +129,7 @@ message ContractGetInfoResponse {
          */
         bytes ledger_id = 12;
         /**
-         * An account to charge for auto-renewal of this contract. If not set, or set to an account with zero hbar
+         * ID of the an account to charge for auto-renewal of this contract. If not set, or set to an account with zero hbar
          * balance, the contract's own hbar balance will be used to cover auto-renewal fees.
          */
         AccountID auto_renew_account_id = 13;


### PR DESCRIPTION
Fixes #176 

- Add `auto_renewal_account_id` to `ContractGetInfo`