### PR TITLE
Add deprecated tag to deprecated response codes

### DIFF
--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1155,9 +1155,9 @@ enum ResponseCodeEnum {
   NEGATIVE_ALLOWANCE_AMOUNT = 290;
 
   /**
-   * The approveForAll flag cannot be set for a fungible token.
+   * [Deprecated] The approveForAll flag cannot be set for a fungible token.
    */
-  CANNOT_APPROVE_FOR_ALL_FUNGIBLE_COMMON = 291;
+  CANNOT_APPROVE_FOR_ALL_FUNGIBLE_COMMON = 291 [deprecated = true];
 
   /**
    * The spender does not have an existing approved allowance with the hbar/token owner.
@@ -1181,15 +1181,15 @@ enum ResponseCodeEnum {
   EMPTY_ALLOWANCES = 295;
 
   /**
-   * Spender is repeated more than once in Crypto or Token or NFT allowance lists in a single
+   * [Deprecated] Spender is repeated more than once in Crypto or Token or NFT allowance lists in a single
    * CryptoApproveAllowance transaction.
    */
-  SPENDER_ACCOUNT_REPEATED_IN_ALLOWANCES = 296;
+  SPENDER_ACCOUNT_REPEATED_IN_ALLOWANCES = 296 [deprecated = true];
 
   /**
-   * Serial numbers are repeated in nft allowance for a single spender account
+   * [Deprecated] Serial numbers are repeated in nft allowance for a single spender account
    */
-  REPEATED_SERIAL_NUMS_IN_NFT_ALLOWANCES = 297;
+  REPEATED_SERIAL_NUMS_IN_NFT_ALLOWANCES = 297 [deprecated = true];
 
   /**
    * Fungible common token used in NFT allowances
@@ -1212,9 +1212,9 @@ enum ResponseCodeEnum {
   INVALID_ALLOWANCE_SPENDER_ID = 301;
 
   /**
-   * If the CryptoDeleteAllowance transaction has repeated crypto or token or Nft allowances to delete.
+   * [Deprecated] If the CryptoDeleteAllowance transaction has repeated crypto or token or Nft allowances to delete.
    */
-  REPEATED_ALLOWANCES_TO_DELETE = 302;
+  REPEATED_ALLOWANCES_TO_DELETE = 302 [deprecated = true];
 
   /**
    * If the account Id specified as the delegating spender is invalid or does not exist.


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

Since , we accepted duplicate entries in allowance transaction bodies , adding `deprecated =true` for all old response codes. These are not being deleted because some old version of allowance changes used them