### PR TITLE
Add max_token_associations to contract_info

### DIFF
--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -134,6 +134,11 @@ message ContractGetInfoResponse {
          * balance, the contract's own hbar balance will be used to cover auto-renewal fees.
          */
         AccountID auto_renew_account_id = 13;
+
+        /**
+         * The maximum number of tokens that a contract can be implicitly associated with.
+         */
+        int32 max_automatic_token_associations = 14;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Neeharika-Sompalli <neeharika.sompalli@hedera.com>

Related to #177 

- Add the `max_automatic_token_associations` to `contract_get_info`