### PR TITLE
Staking changes

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1546,7 +1546,7 @@ message StakingInfo {
     /**
      * The staking period during which either the staking settings for this account or contract changed (such as starting
      * staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
-     * is not currently staked to a node, then the value is -1.
+     * is not currently staked to a node, then this field is not set.
      */
     Timestamp stake_period_start = 2;
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1362,9 +1362,9 @@ message NodeAddress {
     string description = 9;
 
     /**
-     * The amount of tinybars staked to the node
+     * [Deprecated] The amount of tinybars staked to the node
      */
-    int64 stake = 10;
+    int64 stake = 10 [deprecated = true];
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1548,7 +1548,7 @@ message StakingInfo {
      * staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
      * is not currently staked to a node, then the value is -1.
      */
-    int64 stake_period_start = 2;
+    Timestamp stake_period_start = 2;
 
     /**
      * The amount in tinybars that will be received in the next reward situation.
@@ -1561,15 +1561,19 @@ message StakingInfo {
     int64 staked_to_me = 4;
 
     /**
-     * The ID of the node this account or contract is staked to. If this account or contract is not staked to a node,
-     * the value is -1. The default value is -1.
+     * ID of the account or node to which this account or contract is staking. It can never happen that staked_account_id is
+     * non-null and staked_node_id is non-negative at the same time.
      */
-    int64 staked_node_id = 5;
+    oneof staked_id {
 
-    /**
-     * The account to which this account or contract is staking. If not staked to an account, the value is null.
-     * The default value is null. It can never happen that staked_account_id is non-null and staked_node_id is
-     * non-negative at the same time.
-     */
-    AccountID staked_account_id = 6;
+        /**
+         * The account to which this account or contract is staking.The default value is null.
+         */
+        AccountID staked_account_id = 5;
+
+        /**
+         * The ID of the node this account or contract is staked to. The default value is -1.
+         */
+        int64 staked_node_id = 6;
+    }
 }

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1561,18 +1561,17 @@ message StakingInfo {
     int64 staked_to_me = 4;
 
     /**
-     * ID of the account or node to which this account or contract is staking. It can never happen that staked_account_id is
-     * non-null and staked_node_id is non-negative at the same time.
+     * ID of the account or node to which this account or contract is staking.
      */
     oneof staked_id {
 
         /**
-         * The account to which this account or contract is staking.The default value is null.
+         * The account to which this account or contract is staking.
          */
         AccountID staked_account_id = 5;
 
         /**
-         * The ID of the node this account or contract is staked to. The default value is -1.
+         * The ID of the node this account or contract is staked to.
          */
         int64 staked_node_id = 6;
     }

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1532,3 +1532,40 @@ message TokenAssociation {
     TokenID token_id = 1;  // The token involved in the association
     AccountID account_id = 2; // The account involved in the association
 }
+
+/* Staking metadata for an account or a contract */
+message StakingInfo {
+    /**
+     * If true, this account or contract declined to receive a staking reward.
+     */
+    bool decline_reward = 1;
+
+    /**
+     * The staking period during which either the staking settings for this account or contract changed (such as starting
+     * staking or changing stakedNode) or the most recent reward was earned, whichever is later. If this account or contract
+     * is not currently staked to a node, then the value is -1.
+     */
+    int64 stake_period_start = 2;
+
+    /**
+     * The amount in tinybars that will be received in the next reward situation.
+     */
+    int64 pending_reward = 3;
+
+    /**
+     * The sum of balances of all accounts staked to this account or contract.
+     */
+    int64 staked_to_me = 4;
+
+    /**
+     * The ID of the node this account or contract is staked to. If this contract is not staked to a node, the value is -1. The default value is -1.
+     */
+    int64 staked_node_id = 5;
+
+    /**
+     * The account to which the account or contract is staking. If not staked to an account, the value is null.
+     * The default value is null. It can never happen that staked_account_id is non-null and staked_node_id is
+     * non-negative at the same time.
+     */
+    AccountID staked_account_id = 6;
+}

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1533,8 +1533,11 @@ message TokenAssociation {
     AccountID account_id = 2; // The account involved in the association
 }
 
-/* Staking metadata for an account or a contract */
+/**
+ * Staking metadata for an account or a contract returned in CryptoGetInfo or ContractGetInfo queries
+ */
 message StakingInfo {
+
     /**
      * If true, this account or contract declined to receive a staking reward.
      */
@@ -1542,7 +1545,7 @@ message StakingInfo {
 
     /**
      * The staking period during which either the staking settings for this account or contract changed (such as starting
-     * staking or changing stakedNode) or the most recent reward was earned, whichever is later. If this account or contract
+     * staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
      * is not currently staked to a node, then the value is -1.
      */
     int64 stake_period_start = 2;
@@ -1553,17 +1556,18 @@ message StakingInfo {
     int64 pending_reward = 3;
 
     /**
-     * The sum of balances of all accounts staked to this account or contract.
+     * The total of balance of all accounts staked to this account or contract.
      */
     int64 staked_to_me = 4;
 
     /**
-     * The ID of the node this account or contract is staked to. If this contract is not staked to a node, the value is -1. The default value is -1.
+     * The ID of the node this account or contract is staked to. If this account or contract is not staked to a node,
+     * the value is -1. The default value is -1.
      */
     int64 staked_node_id = 5;
 
     /**
-     * The account to which the account or contract is staking. If not staked to an account, the value is null.
+     * The account to which this account or contract is staking. If not staked to an account, the value is null.
      * The default value is null. It can never happen that staked_account_id is non-null and staked_node_id is
      * non-negative at the same time.
      */

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -179,8 +179,7 @@ message ContractCreateTransactionBody {
     AccountID auto_renew_account_id = 15;
 
     /**
-     * ID of the new account or node to which this contract is staking. It can never happen that staked_account_id is
-     * non-null and staked_node_id is non-negative at the same time.
+     * ID of the new account or node to which this contract is staking.
      */
     oneof staked_id {
 

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -127,13 +127,13 @@ message ContractCreateTransactionBody {
     int64 initialBalance = 5;
 
     /**
-     * ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
      * invalid account, or is an account that isn't a node, then this account is automatically proxy
      * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
      * account refuses to accept proxy staking , or if it is not currently running a node, then it
      * will behave as if  proxyAccountID was null.
      */
-    AccountID proxyAccountID = 6;
+    AccountID proxyAccountID = 6 [deprecated = true];
 
     /**
      * the instance will charge its account every this many seconds to renew for this long

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -177,4 +177,14 @@ message ContractCreateTransactionBody {
      * cover auto-renewal fees.
      */
     AccountID auto_renew_account_id = 15;
+
+    /**
+     * ID of the new account to which this contract is staking. If not staked to an account, the value is null. The default value is null.
+     */
+    AccountID staked_account_id = 16;
+
+    /**
+     * If true, the contract declines receiving a staking reward. The default value is false.
+     */
+    google.protobuf.BoolValue decline_reward = 17;
 }

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -185,12 +185,12 @@ message ContractCreateTransactionBody {
     oneof staked_id {
 
         /**
-         * ID of the account to which this contract is staking. The default value is null.
+         * ID of the account to which this contract is staking.
          */
         AccountID staked_account_id = 17;
 
         /**
-         * ID of the node this contract is staked to. The default value is -1.
+         * ID of the node this contract is staked to.
          */
         int64 staked_node_id = 18;
     }

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -27,7 +27,6 @@ option java_multiple_files = true;
 
 import "basic_types.proto";
 import "duration.proto";
-import "google/protobuf/wrappers.proto";
 
 /**
  * Start a new smart contract instance. After the instance is created, the ContractID for it is in
@@ -88,10 +87,10 @@ import "google/protobuf/wrappers.proto";
 message ContractCreateTransactionBody {
 
     /**
-     * There are two ways to specify the initcode of a ContractCreateTransction. If the initcode is 
-     * large (> 5K) then it must be stored in a file as hex encoded ascii. If it is small then it may 
+     * There are two ways to specify the initcode of a ContractCreateTransction. If the initcode is
+     * large (> 5K) then it must be stored in a file as hex encoded ascii. If it is small then it may
      * either be stored as a hex encoded file or as a binary encoded field as part of the transaciton.
-     * 
+     *
      */
     oneof initcodeSource {
         /**
@@ -167,25 +166,38 @@ message ContractCreateTransactionBody {
     string memo = 13;
 
     /**
-     * The maximum number of tokens that this contract can be automatically associated 
+     * The maximum number of tokens that this contract can be automatically associated
      * with (i.e., receive air-drops from).
      */
     int32 max_automatic_token_associations = 14;
 
     /**
-     * An account to charge for auto-renewal of this contract. If not set, or set to an 
-     * account with zero hbar balance, the contract's own hbar balance will be used to 
+     * An account to charge for auto-renewal of this contract. If not set, or set to an
+     * account with zero hbar balance, the contract's own hbar balance will be used to
      * cover auto-renewal fees.
      */
     AccountID auto_renew_account_id = 15;
 
     /**
-     * ID of the new account to which this contract is staking. If not staked to an account, the value is null. The default value is null.
+     * ID of the new account or node to which this contract is staking. It can never happen that staked_account_id is
+     * non-null and staked_node_id is non-negative at the same time.
      */
-    AccountID staked_account_id = 17;
+    oneof staked_id {
+
+        /**
+         * ID of the account to which this contract is staking. If not staked to an account, the value is null.
+         * The default value is null.
+         */
+        AccountID staked_account_id = 17;
+
+        /**
+         * ID of the node this contract is staked to. If not staked to a node, the value is -1. The default value is -1.
+         */
+        int64 staked_node_id = 18;
+    }
 
     /**
      * If true, the contract declines receiving a staking reward. The default value is false.
      */
-    google.protobuf.BoolValue decline_reward = 18;
+    bool decline_reward = 19;
 }

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -185,13 +185,12 @@ message ContractCreateTransactionBody {
     oneof staked_id {
 
         /**
-         * ID of the account to which this contract is staking. If not staked to an account, the value is null.
-         * The default value is null.
+         * ID of the account to which this contract is staking. The default value is null.
          */
         AccountID staked_account_id = 17;
 
         /**
-         * ID of the node this contract is staked to. If not staked to a node, the value is -1. The default value is -1.
+         * ID of the node this contract is staked to. The default value is -1.
          */
         int64 staked_node_id = 18;
     }

--- a/services/contract_create.proto
+++ b/services/contract_create.proto
@@ -27,6 +27,7 @@ option java_multiple_files = true;
 
 import "basic_types.proto";
 import "duration.proto";
+import "google/protobuf/wrappers.proto";
 
 /**
  * Start a new smart contract instance. After the instance is created, the ContractID for it is in
@@ -181,10 +182,10 @@ message ContractCreateTransactionBody {
     /**
      * ID of the new account to which this contract is staking. If not staked to an account, the value is null. The default value is null.
      */
-    AccountID staked_account_id = 16;
+    AccountID staked_account_id = 17;
 
     /**
      * If true, the contract declines receiving a staking reward. The default value is false.
      */
-    google.protobuf.BoolValue decline_reward = 17;
+    google.protobuf.BoolValue decline_reward = 18;
 }

--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -139,6 +139,11 @@ message ContractGetInfoResponse {
          * The maximum number of tokens that a contract can be implicitly associated with.
          */
         int32 max_automatic_token_associations = 14;
+
+        /**
+         * Staking metadata for this contract.
+         */
+        StakingInfo staking_info = 15;
     }
 
     /**

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -111,12 +111,25 @@ message ContractUpdateTransactionBody {
     AccountID auto_renew_account_id = 12;
 
     /**
-     * ID of the new account to which this contract is staking. If not staked to an account, the value is null. The default value is null.
+     * ID of the new account or node to which this contract is staking. It can never happen that staked_account_id
+     * is non-null and staked_node_id is non-negative at the same time.
      */
-    AccountID staked_account_id = 13;
+    oneof staked_id {
+
+        /**
+         * ID of the new account to which this contract is staking. If not staked to an account, the value is null.
+         * The default value is null.
+         */
+        AccountID staked_account_id = 13;
+
+        /**
+         * ID of the new node this contract is staked to. If not staked to a node, the value is -1. The default value is -1.
+         */
+        google.protobuf.Int64Value staked_node_id = 14;
+    }
 
     /**
      * If true, the contract declines receiving a staking reward. The default value is false.
      */
-    google.protobuf.BoolValue decline_reward = 14;
+    google.protobuf.BoolValue decline_reward = 15;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -117,7 +117,7 @@ message ContractUpdateTransactionBody {
 
         /**
          * ID of the new account to which this contract is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
-         * this field removes the contract's staked account.
+         * this field removes the contract's staked account ID.
          */
         AccountID staked_account_id = 13;
 

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -111,24 +111,25 @@ message ContractUpdateTransactionBody {
     AccountID auto_renew_account_id = 12;
 
     /**
-     * ID of the new account or node to which this contract is staking. It can never happen that staked_account_id
-     * is non-null and staked_node_id is non-negative at the same time.
+     * ID of the new account or node to which this contract is staking.
      */
     oneof staked_id {
 
         /**
-         * ID of the new account to which this contract is staking. The default value is null.
+         * ID of the new account to which this contract is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes the contract's staked account.
          */
         AccountID staked_account_id = 13;
 
         /**
-         * ID of the new node this contract is staked to. The default value is -1.
+         * ID of the new node this contract is staked to. If set to the sentinel <tt>-1</tt>, this field
+         * removes the contract's staked node ID.
          */
         google.protobuf.Int64Value staked_node_id = 14;
     }
 
     /**
-     * If true, the contract declines receiving a staking reward. The default value is false.
+     * If true, the contract declines receiving a staking reward.
      */
     google.protobuf.BoolValue decline_reward = 15;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -117,13 +117,12 @@ message ContractUpdateTransactionBody {
     oneof staked_id {
 
         /**
-         * ID of the new account to which this contract is staking. If not staked to an account, the value is null.
-         * The default value is null.
+         * ID of the new account to which this contract is staking. The default value is null.
          */
         AccountID staked_account_id = 13;
 
         /**
-         * ID of the new node this contract is staked to. If not staked to a node, the value is -1. The default value is -1.
+         * ID of the new node this contract is staked to. The default value is -1.
          */
         google.protobuf.Int64Value staked_node_id = 14;
     }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -67,9 +67,9 @@ message ContractUpdateTransactionBody {
     Key adminKey = 3;
 
     /**
-     * (NOT YET IMPLEMENTED) The new id of the account to which the contract is proxy staked
+     * [Deprecated] The new id of the account to which the contract is proxy staked
      */
-    AccountID proxyAccountID = 6;
+    AccountID proxyAccountID = 6 [deprecated = true];
 
     /**
      * (NOT YET IMPLEMENTED) The new interval at which the contract will pay to extend its expiry

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -109,4 +109,14 @@ message ContractUpdateTransactionBody {
      * account. Otherwise it updates the contract's auto-renew account to the referenced account.
      */
     AccountID auto_renew_account_id = 12;
+
+    /**
+     * ID of the new account to which this contract is staking. If not staked to an account, the value is null. The default value is null.
+     */
+    AccountID staked_account_id = 13;
+
+    /**
+     * If true, the contract declines receiving a staking reward. The default value is false.
+     */
+    google.protobuf.BoolValue decline_reward = 14;
 }

--- a/services/contract_update.proto
+++ b/services/contract_update.proto
@@ -125,7 +125,7 @@ message ContractUpdateTransactionBody {
          * ID of the new node this contract is staked to. If set to the sentinel <tt>-1</tt>, this field
          * removes the contract's staked node ID.
          */
-        google.protobuf.Int64Value staked_node_id = 14;
+        int64 staked_node_id = 14;
     }
 
     /**

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -27,7 +27,6 @@ option java_multiple_files = true;
 
 import "basic_types.proto";
 import "duration.proto";
-import "google/protobuf/wrappers.proto";
 
 /*
  * Create a new account. After the account is created, the AccountID for it is in the receipt. It
@@ -133,12 +132,25 @@ message CryptoCreateTransactionBody {
     int32 max_automatic_token_associations = 14;
 
     /**
-     * ID of the account to which this account is staking. If not staked to an account, the value is null. The default value is null.
+     * ID of the account or node to which this account is staking. It can never happen that staked_account_id is non-null
+     * and staked_node_id is non-negative at the same time.
      */
-    AccountID staked_account_id = 15;
+    oneof staked_id {
+
+        /**
+         * ID of the account to which this account is staking. If not staked to an account, the value is null.
+         * The default value is null.
+         */
+        AccountID staked_account_id = 15;
+
+        /**
+         * ID of the node this account is staked to. If not staked to a node, the value is -1. The default value is -1.
+         */
+        int64 staked_node_id = 16;
+    }
 
     /**
      * If true, the account declines receiving a staking reward. The default value is false.
      */
-    google.protobuf.BoolValue decline_reward = 16;
+    bool decline_reward = 17;
 }

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -130,4 +130,14 @@ message CryptoCreateTransactionBody {
      * and up to a maximum value of 1000.
      */
     int32 max_automatic_token_associations = 14;
+
+    /**
+     * ID of the account to which this account is staking. If not staked to an account, the value is null. The default value is null.
+     */
+    AccountID staked_account_id = 15;
+
+    /**
+     * If true, the account declines receiving a staking reward. The default value is false.
+     */
+    google.protobuf.BoolValue decline_reward = 16;
 }

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -138,13 +138,12 @@ message CryptoCreateTransactionBody {
     oneof staked_id {
 
         /**
-         * ID of the account to which this account is staking. If not staked to an account, the value is null.
-         * The default value is null.
+         * ID of the account to which this account is staking. The default value is null.
          */
         AccountID staked_account_id = 15;
 
         /**
-         * ID of the node this account is staked to. If not staked to a node, the value is -1. The default value is -1.
+         * ID of the node this account is staked to. The default value is -1.
          */
         int64 staked_node_id = 16;
     }

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -72,13 +72,13 @@ message CryptoCreateTransactionBody {
     uint64 initialBalance = 2;
 
     /**
-     * ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
      * invalid account, or is an account that isn't a node, then this account is automatically proxy
      * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
      * account refuses to accept proxy staking , or if it is not currently running a node, then it
      * will behave as if proxyAccountID was null.
      */
-    AccountID proxyAccountID = 3;
+    AccountID proxyAccountID = 3 [deprecated = true];
 
     /**
      * [Deprecated]. The threshold amount (in tinybars) for which an account record is created for

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -27,6 +27,7 @@ option java_multiple_files = true;
 
 import "basic_types.proto";
 import "duration.proto";
+import "google/protobuf/wrappers.proto";
 
 /*
  * Create a new account. After the account is created, the AccountID for it is in the receipt. It

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -132,18 +132,17 @@ message CryptoCreateTransactionBody {
     int32 max_automatic_token_associations = 14;
 
     /**
-     * ID of the account or node to which this account is staking. It can never happen that staked_account_id is non-null
-     * and staked_node_id is non-negative at the same time.
+     * ID of the account or node to which this account is staking.
      */
     oneof staked_id {
 
         /**
-         * ID of the account to which this account is staking. The default value is null.
+         * ID of the account to which this account is staking.
          */
         AccountID staked_account_id = 15;
 
         /**
-         * ID of the node this account is staked to. The default value is -1.
+         * ID of the node this account is staked to.
          */
         int64 staked_node_id = 16;
     }

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -79,13 +79,13 @@ message CryptoGetInfoResponse {
         bool deleted = 3;
 
         /**
-         * The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
+         * [Deprecated] The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
          * or is an invalid account, or is an account that isn't a node, then this account is
          * automatically proxy staked to a node chosen by the network, but without earning payments.
          * If the proxyAccountID account refuses to accept proxy staking , or if it is not currently
          * running a node, then it will behave as if proxyAccountID was null.
          */
-        AccountID proxyAccountID = 4;
+        AccountID proxyAccountID = 4 [deprecated = true];
 
         /**
          * The total number of tinybars proxy staked to this account

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -172,6 +172,11 @@ message CryptoGetInfoResponse {
          * The ethereum transaction nonce associated with this account.
          */
         int64 ethereum_nonce = 21;
+
+        /**
+         * Staking metadata for this account.
+         */
+        StakingInfo staking_info = 22;
     }
 
     /**

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -145,7 +145,7 @@ message CryptoUpdateTransactionBody {
          * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
          * removes this account's staked node ID.
          */
-        google.protobuf.Int64Value staked_node_id = 17;
+        int64 staked_node_id = 17;
     }
 
     /**

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -49,13 +49,13 @@ message CryptoUpdateTransactionBody {
     Key key = 3;
 
     /**
-     * ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
      * invalid account, or is an account that isn't a node, then this account is automatically proxy
      * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
      * account refuses to accept proxy staking , or if it is not currently running a node, then it
      * will behave as if proxyAccountID was null.
      */
-    AccountID proxyAccountID = 4;
+    AccountID proxyAccountID = 4 [deprecated = true];
 
     /**
      * [Deprecated]. Payments earned from proxy staking are shared between the node and this

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -137,7 +137,7 @@ message CryptoUpdateTransactionBody {
 
         /**
          * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
-         * this field removes this account's staked account.
+         * this field removes this account's staked account ID.
          */
         AccountID staked_account_id = 16;
 

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -129,4 +129,14 @@ message CryptoUpdateTransactionBody {
      * including implicit and explicit associations.
      */
     google.protobuf.Int32Value max_automatic_token_associations = 15;
+
+    /**
+     * ID of the new account to which this account is staking. If not staked to an account, the value is null. The default value is null.
+     */
+    AccountID staked_account_id = 16;
+
+    /**
+     * If true, the account declines receiving a staking reward. The default value is false.
+     */
+    google.protobuf.BoolValue decline_reward = 17;
 }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -131,12 +131,25 @@ message CryptoUpdateTransactionBody {
     google.protobuf.Int32Value max_automatic_token_associations = 15;
 
     /**
-     * ID of the new account to which this account is staking. If not staked to an account, the value is null. The default value is null.
+     * ID of the account or node to which this account is staking. It can never happen that staked_account_id is non-null
+     * and staked_node_id is non-negative at the same time.
      */
-    AccountID staked_account_id = 16;
+    oneof staked_id {
+
+        /**
+         * ID of the new account to which this account is staking. If not staked to an account, the value is null.
+         * The default value is null.
+         */
+        AccountID staked_account_id = 16;
+
+        /**
+         * ID of the new node this account is staked to. If not staked to a node, the value is -1. The default value is -1.
+         */
+        google.protobuf.Int64Value staked_node_id = 17;
+    }
 
     /**
      * If true, the account declines receiving a staking reward. The default value is false.
      */
-    google.protobuf.BoolValue decline_reward = 17;
+    google.protobuf.BoolValue decline_reward = 18;
 }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -131,18 +131,19 @@ message CryptoUpdateTransactionBody {
     google.protobuf.Int32Value max_automatic_token_associations = 15;
 
     /**
-     * ID of the account or node to which this account is staking. It can never happen that staked_account_id is non-null
-     * and staked_node_id is non-negative at the same time.
+     * ID of the account or node to which this account is staking.
      */
     oneof staked_id {
 
         /**
-         * ID of the new account to which this account is staking. The default value is null.
+         * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes this account's staked account.
          */
         AccountID staked_account_id = 16;
 
         /**
-         * ID of the new node this account is staked to. The default value is -1.
+         * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+         * removes this account's staked node ID.
          */
         google.protobuf.Int64Value staked_node_id = 17;
     }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -137,13 +137,12 @@ message CryptoUpdateTransactionBody {
     oneof staked_id {
 
         /**
-         * ID of the new account to which this account is staking. If not staked to an account, the value is null.
-         * The default value is null.
+         * ID of the new account to which this account is staking. The default value is null.
          */
         AccountID staked_account_id = 16;
 
         /**
-         * ID of the new node this account is staked to. If not staked to a node, the value is -1. The default value is -1.
+         * ID of the new node this account is staked to. The default value is -1.
          */
         google.protobuf.Int64Value staked_node_id = 17;
     }

--- a/services/get_account_details.proto
+++ b/services/get_account_details.proto
@@ -79,13 +79,13 @@ message GetAccountDetailsResponse {
         bool deleted = 3;
 
         /**
-         * The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
+         * [Deprecated] The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
          * or is an invalid account, or is an account that isn't a node, then this account is
          * automatically proxy staked to a node chosen by the network, but without earning payments.
          * If the proxyAccountID account refuses to accept proxy staking , or if it is not currently
          * running a node, then it will behave as if proxyAccountID was null.
          */
-        AccountID proxy_account_id = 4;
+        AccountID proxy_account_id = 4 [deprecated = true];
 
         /**
          * The total number of tinybars proxy staked to this account

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1118,9 +1118,9 @@ enum ResponseCodeEnum {
   UNEXPECTED_TOKEN_DECIMALS = 283;
 
   /**
-   * The proxy account id is invalid or does not exist.
+   * [Deprecated] The proxy account id is invalid or does not exist.
    */
-  INVALID_PROXY_ACCOUNT_ID = 284;
+  INVALID_PROXY_ACCOUNT_ID = 284 [deprecated = true];
 
   /**
    * The transfer account id in CryptoDelete transaction is invalid or does not exist.
@@ -1313,4 +1313,9 @@ enum ResponseCodeEnum {
    * An account set the staked_account_id to itself in CryptoUpdate or ContractUpdate transactions.
    */
   SELF_STAKING_IS_NOT_ALLOWED = 321;
+
+  /**
+   * The staking account id or staking node id given is invalid or does not exist.
+   */
+  INVALID_STAKING_ID = 322;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1303,4 +1303,8 @@ enum ResponseCodeEnum {
    * A delete transaction submitted via HAPI set permanent_removal=true 
    */
   PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
+  /*
+   * A CryptoCreate or ContractCreate used the deprecated proxyAccountID field.
+   */
+  PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED = 320;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1303,8 +1303,14 @@ enum ResponseCodeEnum {
    * A delete transaction submitted via HAPI set permanent_removal=true 
    */
   PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
+
   /*
    * A CryptoCreate or ContractCreate used the deprecated proxyAccountID field.
    */
   PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED = 320;
+
+  /**
+   * An account set the staked_account_id to itself in CryptoUpdate or ContractUpdate transactions.
+   */
+  SELF_STAKING_NOT_ALLOWED = 321;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1312,5 +1312,5 @@ enum ResponseCodeEnum {
   /**
    * An account set the staked_account_id to itself in CryptoUpdate or ContractUpdate transactions.
    */
-  SELF_STAKING_NOT_ALLOWED = 321;
+  SELF_STAKING_IS_NOT_ALLOWED = 321;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -128,4 +128,9 @@ message TransactionRecord {
      * EthereumTransaction.
      */
     bytes ethereum_hash = 17;
+
+    /**
+     * List of accounts with the corresponding staking rewards paid as a result of a transaction.
+     */
+    repeated AccountAmount paid_staking_rewards = 18;
 }


### PR DESCRIPTION
Fixes #169  #170  #171 #172 #173 #174 #175

- Deprecated `proxyAccountID` in `(Crypto/Contract)CreateTransactionBody` , `(Crypto/Contract)UpdateTransactionBody`, (Crypto/Contract)GetInfo
- Deprecated `NodeAddress#stake`
- Added new staking fields to `(Crypto/Contract)CreateTransactionBody` , `(Crypto/Contract)UpdateTransactionBody`
- Added `StakingInfo` and returned in `(Crypto/Contract)GetInfo` query
- Added `paid_staking_rewards` to `TransactionRecord`
- Added ResponseCodes needed