### PR TITLE
`NodeStakeUpdateTransactionBody` for end of period staking info

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1134,6 +1134,11 @@ enum HederaFunctionality {
      * Ethereum Transaction
      */
     EthereumTransaction = 84;
+
+    /**
+     * Updates the staking info at the end of staking period to indicate new staking period has started.
+     */
+    NodeStakeUpdate = 85;
 }
 
 /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -45,13 +45,13 @@ message NodeStakeUpdateTransactionBody {
   /**
    * Staking info of each node at the beginning of the new staking period
    */
-  repeated StakingNodeInfo staking_node_info = 3;
+  repeated NodeStake node_stake = 3;
 }
 
 /**
  * Staking info for each node for the staking period that is ending
  */
-message StakingNodeInfo {
+message NodeStake {
 
   /**
    * Node id of this node
@@ -66,7 +66,7 @@ message StakingNodeInfo {
   /**
    * Total of balance of all accounts staked to this node that have declineReward set to false, at the end of staking period.
    */
-  uint64 stake_rewarded_start = 3;
+  uint64 stake_rewarded = 3;
 
   /**
    * Number of rounds in which it created a famous witness or judge

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -38,14 +38,9 @@ message NodeStakeUpdateTransactionBody {
   Timestamp end_of_staking_period = 1;
 
   /**
-   * Number of rounds during the staking period that is ending
-   */
-  uint32 num_staking_rounds = 2;
-
-  /**
    * Staking info of each node at the beginning of the new staking period
    */
-  repeated NodeStake node_stake = 3;
+  repeated NodeStake node_stake = 2;
 }
 
 /**
@@ -56,20 +51,20 @@ message NodeStake {
   /**
    * Node id of this node
    */
-  uint64 node_id = 1;
+  int64 node_id = 1;
 
   /**
    * Consensus weight for this node, at the end of current staking period.
    */
-  uint64 stake = 2;
+  int64 stake = 2;
 
   /**
    * Total of balance of all accounts staked to this node that have declineReward set to false, at the end of staking period.
    */
-  uint64 stake_rewarded = 3;
+  int64 stake_rewarded = 3;
 
   /**
    * Number of rounds in which it created a famous witness or judge
    */
-  uint32 num_rounds_with_judge = 4;
+  int32 num_rounds_with_judge = 4;
 }

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * The staking update transaction sent at the end of staking period to indicate new staking period has started.
+ */
+message NodeStakeUpdateTransactionBody {
+  /**
+   * Time and date of the end of the staking period that is ending
+   */
+  Timestamp end_of_staking_period = 1;
+
+  /**
+   * Number of rounds during the staking period that is ending
+   */
+  uint64 num_staking_rounds = 2;
+
+  /**
+   * Staking info of each node at the beginning of the new staking period
+   */
+  repeated StakingNodeInfo staking_node_info = 3;
+}
+
+/**
+ * Staking info for each node for the staking period that is ending
+ */
+message StakingNodeInfo {
+  /**
+   * Calculated consensus weight for this node throughout the current staking period.
+   */
+  uint64 stake = 1;
+
+  /**
+   * Total of balance of all accounts staked to this node that have declineReward set to false, at the end of staking period.
+   */
+  uint64 stake_rewarded_start = 2;
+
+  /**
+   * Number of rounds in which it created a famous witness or judge
+   */
+  uint32 num_rounds_with_judge = 3;
+}

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -29,7 +29,7 @@ import "basic_types.proto";
 import "timestamp.proto";
 
 /**
- * The staking update transaction sent at the end of staking period to indicate new staking period has started.
+ * Updates the staking info at the end of staking period to indicate new staking period has started.
  */
 message NodeStakeUpdateTransactionBody {
   /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -40,7 +40,7 @@ message NodeStakeUpdateTransactionBody {
   /**
    * Number of rounds during the staking period that is ending
    */
-  uint64 num_staking_rounds = 2;
+  uint32 num_staking_rounds = 2;
 
   /**
    * Staking info of each node at the beginning of the new staking period

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -62,9 +62,4 @@ message NodeStake {
    * Total of balance of all accounts staked to this node that have declineReward set to false, at the end of staking period.
    */
   int64 stake_rewarded = 3;
-
-  /**
-   * Number of rounds in which it created a famous witness or judge
-   */
-  int32 num_rounds_with_judge = 4;
 }

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -52,18 +52,24 @@ message NodeStakeUpdateTransactionBody {
  * Staking info for each node for the staking period that is ending
  */
 message StakingNodeInfo {
+
   /**
-   * Calculated consensus weight for this node throughout the current staking period.
+   * Node id of this node
    */
-  uint64 stake = 1;
+  uint64 node_id = 1;
+
+  /**
+   * Consensus weight for this node, at the end of current staking period.
+   */
+  uint64 stake = 2;
 
   /**
    * Total of balance of all accounts staked to this node that have declineReward set to false, at the end of staking period.
    */
-  uint64 stake_rewarded_start = 2;
+  uint64 stake_rewarded_start = 3;
 
   /**
    * Number of rounds in which it created a famous witness or judge
    */
-  uint32 num_rounds_with_judge = 3;
+  uint32 num_rounds_with_judge = 4;
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -340,7 +340,7 @@ message TransactionBody {
     ScheduleSignTransactionBody scheduleSign = 44;
 
     /**
-     * The staking update transaction sent at the end of staking period to indicate new staking period has started.
+     * Updates the staking info at the end of staking period to indicate new staking period has started.
      */
     NodeStakeUpdateTransactionBody node_stake_update = 52;
   }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -80,6 +80,8 @@ import "schedule_create.proto";
 import "schedule_delete.proto";
 import "schedule_sign.proto";
 
+import "node_stake_update.proto";
+
 /**
  * A single transaction. All transaction types are possible here.
  */
@@ -336,5 +338,10 @@ message TransactionBody {
      * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
      */
     ScheduleSignTransactionBody scheduleSign = 44;
+
+    /**
+     * The staking update transaction sent at the end of staking period to indicate new staking period has started.
+     */
+    NodeStakeUpdateTransactionBody node_stake_update = 45;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -342,6 +342,6 @@ message TransactionBody {
     /**
      * The staking update transaction sent at the end of staking period to indicate new staking period has started.
      */
-    NodeStakeUpdateTransactionBody node_stake_update = 45;
+    NodeStakeUpdateTransactionBody node_stake_update = 52;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -342,6 +342,6 @@ message TransactionBody {
     /**
      * Updates the staking info at the end of staking period to indicate new staking period has started.
      */
-    NodeStakeUpdateTransactionBody node_stake_update = 52;
+    NodeStakeUpdateTransactionBody node_stake_update = 51;
   }
 }


### PR DESCRIPTION
Related to #175 

- Added `NodeStakeUpdateTransactionBody` which will be used for sending end of staking period values for transaction record
