### PR TITLE
Add more staking metadata to `NodeStakeUpdate` message

### DIFF
--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -40,47 +40,47 @@ message NodeStakeUpdateTransactionBody {
   /**
    * The maximum reward rate, in tinybars per whole hbar, that any account can receive in a day.
    */
-  int64 max_daily_reward_rate = 2;
+  int64 max_daily_reward_rate = 3;
 
   /**
    * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
    * the node reward account 0.0.801.
    */
-  int32 node_reward_fees_percent = 3;
+  int32 node_reward_fees_percent = 4;
 
   /**
    * Staking info of each node at the beginning of the new staking period
    */
-  repeated NodeStake node_stake = 4;
+  repeated NodeStake node_stake = 2;
 
   /**
    * The maximum number of trailing periods for which a user can collect rewards. For example, if this
    * is 365 with a UTC calendar day period, then users must collect rewards at least once per calendar
    * year to avoid missing any value.
    */
-  int64 num_rewardable_trailing_periods = 5;
+  int64 num_rewardable_trailing_periods = 6;
 
   /**
    * The number of minutes in a staking period. Note for the special case of 1440 minutes, periods are 
    * treated as UTC calendar days, rather than repeating 1440 minute periods left-aligned at the epoch.
    */
-  int64 period_mins = 6;
+  int64 period_mins = 7;
 
   /**
    * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
    * the staking reward account 0.0.800.
    */
-  int32 staking_reward_fees_percent = 7;
+  int32 staking_reward_fees_percent = 8;
 
   /**
    * The minimum balance of staking reward account 0.0.800 required to active rewards.
    */
-  int64 start_threshold = 8;
+  int64 start_threshold = 9;
 
   /**
    * The total number of tinybars to be distributed as staking rewards each period.
    */
-  int64 total_rewards_per_period = 9;
+  int64 total_rewards_per_period = 10;
 }
 
 /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -40,13 +40,12 @@ message NodeStakeUpdateTransactionBody {
   /**
    * The maximum reward rate, in tinybars per whole hbar, that any account can receive in a day.
    */
-  int64 max_daily_reward_rate = 3;
+  int64 max_staking_reward_rate_per_hbar = 3;
 
   /**
-   * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
-   * the node reward account 0.0.801.
+   * The fraction of the network and service fees paid to the node reward account 0.0.801.
    */
-  int32 node_reward_fees_percent = 4;
+  Fraction node_reward_fee_fraction = 4;
 
   /**
    * Staking info of each node at the beginning of the new staking period
@@ -58,29 +57,28 @@ message NodeStakeUpdateTransactionBody {
    * is 365 with a UTC calendar day period, then users must collect rewards at least once per calendar
    * year to avoid missing any value.
    */
-  int64 num_rewardable_trailing_periods = 6;
+  int64 staking_periods_stored = 6;
 
   /**
    * The number of minutes in a staking period. Note for the special case of 1440 minutes, periods are 
    * treated as UTC calendar days, rather than repeating 1440 minute periods left-aligned at the epoch.
    */
-  int64 period_mins = 7;
+  int64 staking_period = 7;
 
   /**
-   * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
-   * the staking reward account 0.0.800.
+   * The fraction of the network and service fees paid to the staking reward account 0.0.800.
    */
-  int32 staking_reward_fees_percent = 8;
+  Fraction staking_reward_fee_fraction = 8;
 
   /**
    * The minimum balance of staking reward account 0.0.800 required to active rewards.
    */
-  int64 start_threshold = 9;
+  int64 staking_start_threshold = 9;
 
   /**
    * The total number of tinybars to be distributed as staking rewards each period.
    */
-  int64 total_rewards_per_period = 10;
+  int64 staking_reward_rate = 10;
 }
 
 /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -76,6 +76,11 @@ message NodeStakeUpdateTransactionBody {
    * The minimum balance of staking reward account 0.0.800 required to active rewards.
    */
   int64 start_threshold = 8;
+
+  /**
+   * The total number of tinybars to be distributed as staking rewards each period.
+   */
+  int64 total_rewards_per_period = 9;
 }
 
 /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -38,6 +38,11 @@ message NodeStakeUpdateTransactionBody {
   Timestamp end_of_staking_period = 1;
 
   /**
+   * Staking info of each node at the beginning of the new staking period
+   */
+  repeated NodeStake node_stake = 2;
+
+  /**
    * The maximum reward rate, in tinybars per whole hbar, that any account can receive in a day.
    */
   int64 max_staking_reward_rate_per_hbar = 3;
@@ -48,37 +53,32 @@ message NodeStakeUpdateTransactionBody {
   Fraction node_reward_fee_fraction = 4;
 
   /**
-   * Staking info of each node at the beginning of the new staking period
-   */
-  repeated NodeStake node_stake = 2;
-
-  /**
    * The maximum number of trailing periods for which a user can collect rewards. For example, if this
    * is 365 with a UTC calendar day period, then users must collect rewards at least once per calendar
    * year to avoid missing any value.
    */
-  int64 staking_periods_stored = 6;
+  int64 staking_periods_stored = 5;
 
   /**
    * The number of minutes in a staking period. Note for the special case of 1440 minutes, periods are 
    * treated as UTC calendar days, rather than repeating 1440 minute periods left-aligned at the epoch.
    */
-  int64 staking_period = 7;
+  int64 staking_period = 6;
 
   /**
    * The fraction of the network and service fees paid to the staking reward account 0.0.800.
    */
-  Fraction staking_reward_fee_fraction = 8;
+  Fraction staking_reward_fee_fraction = 7;
 
   /**
    * The minimum balance of staking reward account 0.0.800 required to active rewards.
    */
-  int64 staking_start_threshold = 9;
+  int64 staking_start_threshold = 8;
 
   /**
    * The total number of tinybars to be distributed as staking rewards each period.
    */
-  int64 staking_reward_rate = 10;
+  int64 staking_reward_rate = 9;
 }
 
 /**

--- a/services/node_stake_update.proto
+++ b/services/node_stake_update.proto
@@ -38,9 +38,44 @@ message NodeStakeUpdateTransactionBody {
   Timestamp end_of_staking_period = 1;
 
   /**
+   * The maximum reward rate, in tinybars per whole hbar, that any account can receive in a day.
+   */
+  int64 max_daily_reward_rate = 2;
+
+  /**
+   * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
+   * the node reward account 0.0.801.
+   */
+  int32 node_reward_fees_percent = 3;
+
+  /**
    * Staking info of each node at the beginning of the new staking period
    */
-  repeated NodeStake node_stake = 2;
+  repeated NodeStake node_stake = 4;
+
+  /**
+   * The maximum number of trailing periods for which a user can collect rewards. For example, if this
+   * is 365 with a UTC calendar day period, then users must collect rewards at least once per calendar
+   * year to avoid missing any value.
+   */
+  int64 num_rewardable_trailing_periods = 5;
+
+  /**
+   * The number of minutes in a staking period. Note for the special case of 1440 minutes, periods are 
+   * treated as UTC calendar days, rather than repeating 1440 minute periods left-aligned at the epoch.
+   */
+  int64 period_mins = 6;
+
+  /**
+   * The fraction of the network and service fees (as a whole number in the range [0, 100]) paid to 
+   * the staking reward account 0.0.800.
+   */
+  int32 staking_reward_fees_percent = 7;
+
+  /**
+   * The minimum balance of staking reward account 0.0.800 required to active rewards.
+   */
+  int64 start_threshold = 8;
 }
 
 /**


### PR DESCRIPTION
**Description**:
Add fields to export the following staking Services properties:
```
### Dynamic properties, can be changed via FileUpdate to 0.0.121
staking.fees.nodeRewardPercentage=0                                              
staking.fees.stakingRewardPercentage=100                                         
staking.maxDailyStakeRewardThPerH=17_808                                                                                           
staking.rewardRate=0                                                         
staking.startThreshold=250_000_000_00_000_000
### Static properties, can only change on network restart
staking.periodMins=1440
staking.rewardHistory.numStoredPeriods=365
```