### PR TITLE
Add `MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED`

### DIFF
--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1328,4 +1328,9 @@ enum ResponseCodeEnum {
    * The range provided in RandomGenerate transaction is negative.
    */
   INVALID_RANDOM_GENERATE_RANGE = 324;
+
+  /**
+   * The maximum number of entities allowed in the current price regime have been created.
+   */
+  MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED = 325;
 }


### PR DESCRIPTION
**Description**:
 - Adds a response code that Services can use to for a `*Create` transaction that fails because the max supported number of entities has been reached.