### PR TITLE
Hip-351 : Change name of `prng` txn to `utilPrng`

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1143,7 +1143,7 @@ enum HederaFunctionality {
     /**
      * Generates a pseudorandom number.
      */
-    PRNG = 86;
+    UtilPrng = 86;
 }
 
 /**

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1325,7 +1325,7 @@ enum ResponseCodeEnum {
   STAKING_NOT_ENABLED = 323;
 
   /**
-   * The range provided in PRNG transaction is negative.
+   * The range provided in UtilPrng transaction is negative.
    */
   INVALID_PRNG_RANGE = 324;
 

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -69,7 +69,7 @@ import "token_pause.proto";
 import "token_unpause.proto";
 
 import "schedule_delete.proto";
-import "prng.proto";
+import "util_prng.proto";
 
 /**
  * A schedulable transaction. Note that the global/dynamic system property
@@ -281,6 +281,6 @@ message SchedulableTransactionBody {
     /**
      * Generates a pseudorandom number.
      */
-    PrngTransactionBody prng = 40;
+    UtilPrngTransactionBody util_prng = 40;
   }
 }

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -81,7 +81,7 @@ import "schedule_delete.proto";
 import "schedule_sign.proto";
 
 import "node_stake_update.proto";
-import "prng.proto";
+import "util_prng.proto";
 
 /**
  * A single transaction. All transaction types are possible here.
@@ -348,6 +348,6 @@ message TransactionBody {
     /**
      * Generates a pseudorandom number.
      */
-    PrngTransactionBody prng = 52;
+    UtilPrngTransactionBody util_prng = 52;
   }
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -136,7 +136,7 @@ message TransactionRecord {
 
     oneof entropy {
         /**
-         * In the record of a PRNG transaction with no output range, a pseudorandom 384-bit string.
+         * In the record of a UtilPrng transaction with no output range, a pseudorandom 384-bit string.
          */
         bytes prng_bytes = 19;
 

--- a/services/util_prng.proto
+++ b/services/util_prng.proto
@@ -28,7 +28,7 @@ option java_multiple_files = true;
 /**
  * Generates a pseudorandom number
  */
-message PrngTransactionBody {
+message UtilPrngTransactionBody {
   /**
    * If provided and is positive, returns a 32-bit pseudorandom number from the given range in the transaction record.
    * If not set or set to zero, will return a 384-bit pseudorandom number in the record.

--- a/services/util_service.proto
+++ b/services/util_service.proto
@@ -34,5 +34,5 @@ service UtilService {
   /**
    * Generates a pseudorandom number.
    */
-  rpc utilPrng (Transaction) returns (TransactionResponse);
+  rpc prng (Transaction) returns (TransactionResponse);
 }

--- a/services/util_service.proto
+++ b/services/util_service.proto
@@ -34,5 +34,5 @@ service UtilService {
   /**
    * Generates a pseudorandom number.
    */
-  rpc prng (Transaction) returns (TransactionResponse);
+  rpc utilPrng (Transaction) returns (TransactionResponse);
 }

--- a/services/util_service.proto
+++ b/services/util_service.proto
@@ -34,5 +34,5 @@ service UtilService {
   /**
    * Generates a pseudorandom number.
    */
-  rpc util_prng (Transaction) returns (TransactionResponse);
+  rpc utilPrng (Transaction) returns (TransactionResponse);
 }

--- a/services/util_service.proto
+++ b/services/util_service.proto
@@ -34,5 +34,5 @@ service UtilService {
   /**
    * Generates a pseudorandom number.
    */
-  rpc utilPrng (Transaction) returns (TransactionResponse);
+  rpc util_prng (Transaction) returns (TransactionResponse);
 }


### PR DESCRIPTION
Related to HIP-351 .
Change name of `prng` transaction to `utilPrng` as per latest discussion, to maintain naming standards for the transaction and transaction body.