### PR TITLE
Deprecate token relationships fields

### DIFF
--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -122,7 +122,7 @@ message ContractGetInfoResponse {
         /**
          * The tokens associated to the contract
          */
-        repeated TokenRelationship tokenRelationships = 11;
+        repeated TokenRelationship tokenRelationships = 11 [deprecated = true];
 
         /**
          * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 

--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -120,7 +120,10 @@ message ContractGetInfoResponse {
         bool deleted = 10;
 
         /**
-         * The tokens associated to the contract
+         * [DEPRECATED] The metadata of the tokens associated to the contract. This field was 
+         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+         * an account to be associated to an unlimited number of tokens. This scale makes it more 
+         * efficient for users to consult mirror nodes to review their token associations.
          */
         repeated TokenRelationship tokenRelationships = 11 [deprecated = true];
 

--- a/services/crypto_get_account_balance.proto
+++ b/services/crypto_get_account_balance.proto
@@ -78,5 +78,5 @@ message CryptoGetAccountBalanceResponse {
     /**
      * The token balances possessed by the target account.
      */
-    repeated TokenBalance tokenBalances = 4;
+    repeated TokenBalance tokenBalances = 4 [deprecated = true];
 }

--- a/services/crypto_get_account_balance.proto
+++ b/services/crypto_get_account_balance.proto
@@ -76,7 +76,10 @@ message CryptoGetAccountBalanceResponse {
     uint64 balance = 3;
 
     /**
-     * The token balances possessed by the target account.
+     * [DEPRECATED] The balances of the tokens associated to the account. This field was 
+     * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+     * an account to be associated to an unlimited number of tokens. This scale makes it more 
+     * efficient for users to consult mirror nodes to review their token balances.
      */
     repeated TokenBalance tokenBalances = 4 [deprecated = true];
 }

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -141,7 +141,7 @@ message CryptoGetInfoResponse {
         /**
          * All tokens related to this account
          */
-        repeated TokenRelationship tokenRelationships = 15;
+        repeated TokenRelationship tokenRelationships = 15 [deprecated = true];
 
         /**
          * The memo associated with the account

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -139,7 +139,10 @@ message CryptoGetInfoResponse {
         repeated LiveHash liveHashes = 14;
 
         /**
-         * All tokens related to this account
+         * [DEPRECATED] The metadata of the tokens associated to the account. This field was 
+         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+         * an account to be associated to an unlimited number of tokens. This scale makes it more 
+         * efficient for users to consult mirror nodes to review their token associations.
          */
         repeated TokenRelationship tokenRelationships = 15 [deprecated = true];
 


### PR DESCRIPTION
**Description**:
 - Mark several fields `deprecated` that will be removed in Nov release (c.f. [here](https://www.notion.so/swirldslabs/HIP-367-Token-Information-Deprecation-15aff829f32f488b90cbc3732b17d305)).