### PR TITLE
Add alias bytes to crypto create

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -95,7 +95,8 @@ message AccountID {
          * a protobuf Key message for any primitive key type. Currently only primitive key bytes are supported as an alias
          * (ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported)
          *
-         * May also be the ethereum account 20-byte EVM address to be used initially in place of the public key bytes.
+         * May also be the ethereum account 20-byte EVM address to be used initially in place of the public key bytes. This EVM
+         * address may be either the encoded form of the shard.realm.num or the keccak-256 hash of a ECDSA_SECP256K1 primitive key.
          *
          * At most one account can ever have a given alias and it is used for account creation if it
          * was automatically created using a crypto transfer. It will be null if an account is created normally.

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -104,8 +104,8 @@ message AccountID {
          * If a transaction auto-creates the account, any further transfers to that alias will simply be deposited
          * in that account, without creating anything, and with no creation fee being charged.
          *
-         * If a transaction lazy-create this account, a susequent transaction will be required containing the public key bytes 
-         * that map to the ethereum account address bytes. The provided public key bytes will then serve as the final alias bytes.
+         * If a transaction lazily-creates this account, a subsequent transaction will be required containing the public key bytes 
+         * that map to the EVM address bytes. The provided public key bytes will then serve as the final alias bytes.
          */
         bytes alias = 4;
 

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -95,12 +95,17 @@ message AccountID {
          * a protobuf Key message for any primitive key type. Currently only primitive key bytes are supported as an alias
          * (ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported)
          *
+         * May also be the ethereum account 20-byte EVM address to be used initially in place of the public key bytes.
+         *
          * At most one account can ever have a given alias and it is used for account creation if it
          * was automatically created using a crypto transfer. It will be null if an account is created normally.
          * It is immutable once it is set for an account.
          *
          * If a transaction auto-creates the account, any further transfers to that alias will simply be deposited
          * in that account, without creating anything, and with no creation fee being charged.
+         *
+         * If a transaction lazy-create this account, a susequent transaction will be required containing the public key bytes 
+         * that map to the ethereum account address bytes. The provided public key bytes will then serve as the final alias bytes.
          */
         bytes alias = 4;
 

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -160,7 +160,8 @@ message CryptoCreateTransactionBody {
      * supported as the key for an account with an alias. ThresholdKey, KeyList, ContractID, and
      * delegatable_contract_id are not supported.
      *
-     * At most only one account can ever have a given alias on the network.
+     * A given alias can map to at most one account on the network at a time. This uniqueness will be enforced
+     * relative to aliases currently on the network at alias assignment.
      *
      * If a transaction creates an account using an alias, any further crypto transfers to that alias will 
      * simply be deposited in that account, without creating anything, and with no creation fee being charged.

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -153,16 +153,17 @@ message CryptoCreateTransactionBody {
     bool decline_reward = 17;
 
     /**
-     * The bytes to be used as the account's alias. The bytes will be 1 of 2 options. 
-     * It will be the serialization of a protobuf Key message for an ED25519/ECDSA primitive key type. 
-     * Or the if the account is ECDSA based it may also be the public address, calcluated as the last 20 bytes of the keccak-256 of the ECDSA primitive key.
-     * Currently only primitive key bytes are supported as the key for an account with an alias. 
-     * ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported.
+     * The bytes to be used as the account's alias. The bytes will be 1 of 2 options. It will be the 
+     * serialization of a protobuf Key message for an ED25519/ECDSA_SECP256K1 primitive key type. If the 
+     * account is ECDSA_SECP256K1 based it may also be the public address, calcluated as the last 20 bytes of
+     * the keccak-256 hash of the ECDSA_SECP256K1 primitive key. Currently only primitive key bytes are 
+     * supported as the key for an account with an alias. ThresholdKey, KeyList, ContractID, and
+     * delegatable_contract_id are not supported.
      *
      * At most only one account can ever have a given alias on the network.
      *
-     * If a transaction creates an account using an alias, any further crypto transfers to that alias will simply be deposited
-     * in that account, without creating anything, and with no creation fee being charged.
+     * If a transaction creates an account using an alias, any further crypto transfers to that alias will 
+     * simply be deposited in that account, without creating anything, and with no creation fee being charged.
      */
      bytes alias = 18;
 }

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -151,4 +151,18 @@ message CryptoCreateTransactionBody {
      * If true, the account declines receiving a staking reward. The default value is false.
      */
     bool decline_reward = 17;
+
+    /**
+     * The bytes to be used as the account's alias. The bytes will be 1 of 2 options. 
+     * It will be the serialization of a protobuf Key message for an ED25519/ECDSA primitive key type. 
+     * Or the if the account is ECDSA based it may also be the public address, calcluated as the last 20 bytes of the keccak-256 of the ECDSA primitive key.
+     * Currently only primitive key bytes are supported as the key for an account with an alias. 
+     * ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported.
+     *
+     * At most only one account can ever have a given alias on the network.
+     *
+     * If a transaction creates an account using an alias, any further crypto transfers to that alias will simply be deposited
+     * in that account, without creating anything, and with no creation fee being charged.
+     */
+	bytes alias = 18;
 }

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -164,5 +164,5 @@ message CryptoCreateTransactionBody {
      * If a transaction creates an account using an alias, any further crypto transfers to that alias will simply be deposited
      * in that account, without creating anything, and with no creation fee being charged.
      */
-	bytes alias = 18;
+     bytes alias = 18;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -118,8 +118,8 @@ message TransactionRecord {
     Timestamp parent_consensus_timestamp = 15;
 
     /**
-     * In the record of an internal CryptoCreate transaction triggered by a user 
-     * transaction with a (previously unused) alias, the new account's alias. 
+     * In the record of a CryptoCreate transaction triggered by a user transaction with a
+     * (previously unused) alias, the new account's alias. 
      */
      bytes alias = 16;
 


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
To support the increased support of the alias in the CryptoCreate Transaction

- Add alias bytes to crypto create
- Update `AccountID.alias` description
- Update `TransactionRecord.alias` description

**Related issue(s)**:

Fixes #222 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
