### PR TITLE
add CallOperationType enum and corresponding field to ContractAction

### DIFF
--- a/streams/contract_action.proto
+++ b/streams/contract_action.proto
@@ -65,7 +65,7 @@ enum ContractActionType {
 }
 
 /**
- * The specific operation type of a call. The OP prefix added to avoid name collisions for
+ * The specific operation type of a call. The OP prefix has been added to avoid name collisions for
  * the CALL and CREATE operation types.
  */
 enum CallOperationType {

--- a/streams/contract_action.proto
+++ b/streams/contract_action.proto
@@ -66,7 +66,8 @@ enum ContractActionType {
 
 /**
  * The specific operation type of a call. The OP prefix has been added to avoid name collisions for
- * the CALL and CREATE operation types.
+ * the CALL and CREATE operation types since both ContractActionType and CallOperationType enums are
+ * used in ContractAction
  */
 enum CallOperationType {
   /**

--- a/streams/contract_action.proto
+++ b/streams/contract_action.proto
@@ -65,6 +65,47 @@ enum ContractActionType {
 }
 
 /**
+ * The specific operation type of a call. The OP prefix added to avoid name collisions for
+ * the CALL and CREATE operation types.
+ */
+enum CallOperationType {
+  /**
+   * default operation type is UNKNOWN
+   */
+  OP_UNKNOWN = 0;
+
+  /**
+   * CALL operation type.
+   */
+  OP_CALL = 1;
+
+  /**
+   * CALLCODE operation type
+   */
+  OP_CALLCODE = 2;
+
+  /**
+   * DELEGATECALL operation type
+   */
+  OP_DELEGATECALL = 3;
+
+  /**
+   * STATICCALL operation type
+   */
+  OP_STATICCALL = 4;
+
+  /**
+   * CREATE operation type
+   */
+  OP_CREATE = 5;
+
+  /**
+   * CREATE2 operation type
+   */
+  OP_CREATE2 = 6;
+}
+
+/**
  * A finer grained action with a function result. Sometimes called "internal transactions." The function call itself
  * will be the first action in a list, followed by sub-action in the order they were executed.
  */
@@ -157,4 +198,9 @@ message ContractAction {
    * The nesting depth of this call. The original action is at depth=0.
    */
   int32 call_depth = 14;
+
+  /**
+   * The call operation type
+   */
+  CallOperationType call_operation_type = 15;
 }


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Add CallOperationType enum.  This will be used to track the specific operation associated with a given contract action.

Fixes #221 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
