### PR TITLE
Add `all_collectors_are_exempt` field to `CustomFee` message.

### DIFF
--- a/services/custom_fees.proto
+++ b/services/custom_fees.proto
@@ -120,6 +120,14 @@ message CustomFee {
    * The account to receive the custom fee
    */
   AccountID fee_collector_account_id = 3;
+
+  /**
+   * If true, exempts all the token's fee collection accounts from this fee.
+   * (The token's treasury and the above fee_collector_account_id will always
+   * be exempt. Please see <a href="https://hips.hedera.com/hip/hip-573">HIP-573</a> 
+   * for details.)
+   */
+  bool all_collectors_are_exempt = 5;
 }
 
 /**


### PR DESCRIPTION
**Description**:
 - Required for a backward-compatible implementation of [HIP-573](https://hips.hedera.com/hip/hip-573).