### PR TITLE
removed instances of non-deprecated uints being used

### DIFF
--- a/services/BasicTypes.proto
+++ b/services/BasicTypes.proto
@@ -197,7 +197,7 @@ message Key {
 
 /* A set of public keys that are used together to form a threshold signature. If the threshold is N and there are M keys, then this is an N of M threshold signature. If an account is associated with ThresholdKeys, then a transaction to move cryptocurrency out of it must be signed by a list of M signatures, where at most M-N of them are blank, and the other at least N of them are valid signatures corresponding to at least N of the public keys listed here. */
 message ThresholdKey {
-    uint32 threshold = 1; // A valid signature set must have at least this many signatures
+    int32 threshold = 1; // A valid signature set must have at least this many signatures
     KeyList keys = 2; // List of all the keys that can sign
 }
 
@@ -455,10 +455,10 @@ message ServicesConfigurationList {
 message TokenRelationship {
     TokenID tokenId = 1; // The ID of the token
     string symbol = 2; // The Symbol of the token
-    uint64 balance = 3; // For token of type FUNGIBLE_COMMON - the balance that the Account holds in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
+    int64 balance = 3; // For token of type FUNGIBLE_COMMON - the balance that the Account holds in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
     TokenKycStatus kycStatus = 4; // The KYC status of the account (KycNotApplicable, Granted or Revoked). If the token does not have KYC key, KycNotApplicable is returned
     TokenFreezeStatus freezeStatus = 5; // The Freeze status of the account (FreezeNotApplicable, Frozen or Unfrozen). If the token does not have Freeze key, FreezeNotApplicable is returned
-    uint32 decimals = 6; // Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
+    int32 decimals = 6; // Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
 }
 
 /* A number of <i>transferable units</i> of a certain token.
@@ -468,8 +468,8 @@ The transferable unit of a token is its smallest denomination, as given by the t
 Transferable units are not directly comparable across different tokens. */
 message TokenBalance {
     TokenID tokenId = 1; // A unique token id
-    uint64 balance = 2; // Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON - balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
-    uint32 decimals = 3; // Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
+    int64 balance = 2; // Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON - balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
+    int32 decimals = 3; // Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
 }
 
 /* A sequence of token balances */

--- a/services/ConsensusTopicInfo.proto
+++ b/services/ConsensusTopicInfo.proto
@@ -42,7 +42,7 @@ message ConsensusTopicInfo {
     bytes runningHash = 2;
 
     // Sequence number (starting at 1 for the first submitMessage) of messages on the topic.
-    uint64 sequenceNumber = 3;
+    int64 sequenceNumber = 3;
 
     // Effective consensus timestamp at (and after) which submitMessage calls will no longer succeed on the topic
     // and the topic will expire and after AUTORENEW_GRACE_PERIOD be automatically deleted.

--- a/services/ContractCallLocal.proto
+++ b/services/ContractCallLocal.proto
@@ -43,7 +43,7 @@ message ContractFunctionResult {
     bytes contractCallResult = 2; // the result returned by the function
     string errorMessage = 3; // message In case there was an error during smart contract execution
     bytes bloom = 4; // bloom filter for record
-    uint64 gasUsed = 5; // units of gas used to execute contract
+    int64 gasUsed = 5; // units of gas used to execute contract
     repeated ContractLoginfo logInfo = 6; // the log info for events returned by the function
     repeated ContractID createdContractIDs = 7; // the list of smart contracts that were created by the function call
 }

--- a/services/ContractGetInfo.proto
+++ b/services/ContractGetInfo.proto
@@ -49,7 +49,7 @@ message ContractGetInfoResponse {
         Duration autoRenewPeriod = 6; // the expiration time will extend every this many seconds. If there are insufficient funds, then it extends as long as possible. If the account is empty when it expires, then it is deleted.
         int64 storage = 7; // number of bytes of storage being used by this instance (which affects the cost to extend the expiration time)
         string memo = 8; // the memo associated with the contract (max 100 bytes)
-        uint64 balance = 9; // The current balance, in tinybars
+        int64 balance = 9; // The current balance, in tinybars
         bool deleted = 10; // Whether the contract has been deleted
         repeated TokenRelationship tokenRelationships = 11; // The tokens associated to the contract
     }

--- a/services/CryptoCreate.proto
+++ b/services/CryptoCreate.proto
@@ -37,7 +37,7 @@ The current API ignores shardID, realmID, and newRealmAdminKey, and creates ever
  */
 message CryptoCreateTransactionBody {
     Key key = 1; // The key that must sign each transfer out of the account. If receiverSigRequired is true, then it must also sign any transfer into the account.
-    uint64 initialBalance = 2; // The initial number of tinybars to put into the account
+    int64 initialBalance = 2; // The initial number of tinybars to put into the account
     AccountID proxyAccountID = 3; // ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an invalid account, or is an account that isn't a node, then this account is automatically proxy staked to a node chosen by the network, but without earning payments. If the proxyAccountID account refuses to accept proxy staking , or if it is not currently running a node, then it will behave as if proxyAccountID was null.
     uint64 sendRecordThreshold = 6 [deprecated=true]; // [Deprecated]. The threshold amount (in tinybars) for which an account record is created for any send/withdraw transaction
     uint64 receiveRecordThreshold = 7 [deprecated=true]; // [Deprecated]. The threshold amount (in tinybars) for which an account record is created for any receive/deposit transaction

--- a/services/CryptoGetAccountBalance.proto
+++ b/services/CryptoGetAccountBalance.proto
@@ -44,6 +44,6 @@ message CryptoGetAccountBalanceQuery {
 message CryptoGetAccountBalanceResponse {
     ResponseHeader header = 1; // Standard response from node to client, including the requested fields: cost, or state proof, or both, or neither.
     AccountID accountID = 2; // The account ID that is being described (this is useful with state proofs, for proving to a third party)
-    uint64 balance = 3; // The current balance, in tinybars.
+    int64 balance = 3; // The current balance, in tinybars.
     repeated TokenBalance tokenBalances = 4; // The token balances possessed by the target account.
 }

--- a/services/CryptoGetInfo.proto
+++ b/services/CryptoGetInfo.proto
@@ -49,7 +49,7 @@ message CryptoGetInfoResponse {
         AccountID proxyAccountID = 4; // The Account ID of the account to which this is proxy staked. If proxyAccountID is null, or is an invalid account, or is an account that isn't a node, then this account is automatically proxy staked to a node chosen by the network, but without earning payments. If the proxyAccountID account refuses to accept proxy staking , or if it is not currently running a node, then it will behave as if proxyAccountID was null.
         int64 proxyReceived = 6; // The total number of tinybars proxy staked to this account
         Key key = 7; // The key for the account, which must sign in order to transfer out, or to modify the account in any way other than extending its expiration date.
-        uint64 balance = 8; // The current balance of account in tinybars
+        int64 balance = 8; // The current balance of account in tinybars
         // [Deprecated]. The threshold amount, in tinybars, at which a record is created of any transaction that decreases the balance of this account by more than the threshold
         uint64 generateSendRecordThreshold = 9 [deprecated=true];
         // [Deprecated]. The threshold amount, in tinybars, at which a record is created of any transaction that increases the balance of this account by more than the threshold

--- a/services/ResponseHeader.proto
+++ b/services/ResponseHeader.proto
@@ -33,6 +33,6 @@ import "ResponseCode.proto";
 message ResponseHeader {
     ResponseCodeEnum nodeTransactionPrecheckCode = 1; // Result of fee transaction precheck, saying it passed, or why it failed
     ResponseType responseType = 2; // The requested response is repeated back here, for convenience
-    uint64 cost = 3; // The fee that would be charged to get the requested information (if a cost was requested). Note: This cost only includes the query fee and does not include the transfer fee(which is required to execute the transfer transaction to debit the payer account and credit the node account with query fee)
+    int64 cost = 3; // The fee that would be charged to get the requested information (if a cost was requested). Note: This cost only includes the query fee and does not include the transfer fee(which is required to execute the transfer transaction to debit the payer account and credit the node account with query fee)
     bytes stateProof = 4; // The state proof for this information (if a state proof was requested, and is available)
 }

--- a/services/SchedulableTransactionBody.proto
+++ b/services/SchedulableTransactionBody.proto
@@ -70,7 +70,7 @@ import "ScheduleDelete.proto";
 In Hedera Services 0.13.0, it will include only <tt>CryptoTransfer</tt> and
 <tt>ConsensusSubmitMessage</tt> functions. */
 message SchedulableTransactionBody {
-  uint64 transactionFee = 1; // The maximum transaction fee the client is willing to pay
+  int64 transactionFee = 1; // The maximum transaction fee the client is willing to pay
   string memo = 2; // A memo to include the execution record; the UTF-8 encoding may be up to 100 bytes and must not include the zero byte
   oneof data {
     ContractCallTransactionBody contractCall = 3; // Calls a function of a contract instance

--- a/services/ThrottleDefinitions.proto
+++ b/services/ThrottleDefinitions.proto
@@ -33,13 +33,13 @@ document in the <a href="https://github.com/hashgraph/hedera-services">Hedera Se
 /* A set of operations which should be collectively throttled at a given milli-ops-per-second limit. */
 message ThrottleGroup {
   repeated HederaFunctionality operations = 1; // The operations to be throttled
-  uint64 milliOpsPerSec = 2; // The number of total operations per second across the entire network, multiplied by 1000. So, to choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
+  int64 milliOpsPerSec = 2; // The number of total operations per second across the entire network, multiplied by 1000. So, to choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
 }
 
 /* A list of throttle groups that should all compete for the same internal bucket. */
 message ThrottleBucket {
   string name = 1; // A name for this bucket (primarily for use in logs)
-  uint64 burstPeriodMs = 2; // The number of milliseconds required for this bucket to drain completely when full. The product of this number and the least common multiple of the milliOpsPerSec values in this bucket must not exceed 9223372036.
+  int64 burstPeriodMs = 2; // The number of milliseconds required for this bucket to drain completely when full. The product of this number and the least common multiple of the milliOpsPerSec values in this bucket must not exceed 9223372036.
   repeated ThrottleGroup throttleGroups = 3; // The throttle groups competing for this bucket
 }
 

--- a/services/TokenBurn.proto
+++ b/services/TokenBurn.proto
@@ -35,6 +35,6 @@ Token A has 2 decimals. In order to burn 100 tokens, one must provide amount of 
  */
 message TokenBurnTransactionBody {
     TokenID token = 1; // The token for which to burn tokens. If token does not exist, transaction results in INVALID_TOKEN_ID
-    uint64 amount = 2; // Applicable to tokens of type FUNGIBLE_COMMON. The amount to burn from the Treasury Account. Amount must be a positive non-zero number, not bigger than the token balance of the treasury account (0; balance], represented in the lowest denomination.
+    int64 amount = 2; // Applicable to tokens of type FUNGIBLE_COMMON. The amount to burn from the Treasury Account. Amount must be a positive non-zero number, not bigger than the token balance of the treasury account (0; balance], represented in the lowest denomination.
     repeated int64 serialNumbers = 3; // Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be burned.
 }

--- a/services/TokenCreate.proto
+++ b/services/TokenCreate.proto
@@ -44,8 +44,8 @@ Note that a created token is <i>immutable</i> if the <tt>adminKey</tt> is omitte
 message TokenCreateTransactionBody {
     string name = 1; // The publicly visible name of the token, limited to a UTF-8 encoding of length <tt>tokens.maxSymbolUtf8Bytes</tt>.
     string symbol = 2; // The publicly visible token symbol, limited to a UTF-8 encoding of length <tt>tokens.maxTokenNameUtf8Bytes</tt>.
-    uint32 decimals = 3; // For tokens of type FUNGIBLE_COMMON - the number of decimal places a token is divisible by. For tokens of type NON_FUNGIBLE_UNIQUE - value must be 0
-    uint64 initialSupply = 4; // Specifies the initial supply of tokens to be put in circulation. The initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible. In the case for NON_FUNGIBLE_UNIQUE Type the value must be 0
+    int32 decimals = 3; // For tokens of type FUNGIBLE_COMMON - the number of decimal places a token is divisible by. For tokens of type NON_FUNGIBLE_UNIQUE - value must be 0
+    int64 initialSupply = 4; // Specifies the initial supply of tokens to be put in circulation. The initial supply is sent to the Treasury Account. The supply is in the lowest denomination possible. In the case for NON_FUNGIBLE_UNIQUE Type the value must be 0
     AccountID treasury = 5; // The account which will act as a treasury for the token. This account will receive the specified initial supply or the newly minted NFTs in the case for NON_FUNGIBLE_UNIQUE Type
     Key adminKey = 6; // The key which can perform update/delete operations on the token. If empty, the token can be perceived as immutable (not being able to be updated/deleted)
     Key kycKey = 7; // The key which can grant or revoke KYC of an account for the token's transactions. If empty, KYC is not required, and KYC grant or revoke operations are not possible.

--- a/services/TokenGetInfo.proto
+++ b/services/TokenGetInfo.proto
@@ -42,8 +42,8 @@ message TokenInfo {
     TokenID tokenId = 1; // ID of the token instance
     string name = 2; // The name of the token. It is a string of ASCII only characters
     string symbol = 3; // The symbol of the token. It is a UTF-8 capitalized alphabetical string
-    uint32 decimals = 4; // The number of decimal places a token is divisible by. Always 0 for tokens of type NON_FUNGIBLE_UNIQUE
-    uint64 totalSupply = 5; // For tokens of type FUNGIBLE_COMMON - the total supply of tokens that are currently in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the number of NFTs created of this token instance
+    int32 decimals = 4; // The number of decimal places a token is divisible by. Always 0 for tokens of type NON_FUNGIBLE_UNIQUE
+    int64 totalSupply = 5; // For tokens of type FUNGIBLE_COMMON - the total supply of tokens that are currently in circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the number of NFTs created of this token instance
     AccountID treasury = 6; // The ID of the account which is set as Treasury
     Key adminKey = 7; // The key which can perform update/delete operations on the token. If empty, the token can be perceived as immutable (not being able to be updated/deleted)
     Key kycKey = 8; // The key which can grant or revoke KYC of an account for the token's transactions. If empty, KYC is not required, and KYC grant or revoke operations are not possible.

--- a/services/TokenMint.proto
+++ b/services/TokenMint.proto
@@ -35,6 +35,6 @@ Token A has 2 decimals. In order to mint 100 tokens, one must provide amount of 
  */
 message TokenMintTransactionBody {
     TokenID token = 1; // The token for which to mint tokens. If token does not exist, transaction results in INVALID_TOKEN_ID
-    uint64 amount = 2; // Applicable to tokens of type FUNGIBLE_COMMON. The amount to mint to the Treasury Account. Amount must be a positive non-zero number represented in the lowest denomination of the token. The new supply must be lower than 2^63.
+    int64 amount = 2; // Applicable to tokens of type FUNGIBLE_COMMON. The amount to mint to the Treasury Account. Amount must be a positive non-zero number represented in the lowest denomination of the token. The new supply must be lower than 2^63.
     repeated bytes metadata = 3; // Applicable to tokens of type NON_FUNGIBLE_UNIQUE. A list of metadata that are being created. Maximum allowed size of each metadata is 100 bytes
 }

--- a/services/TokenWipeAccount.proto
+++ b/services/TokenWipeAccount.proto
@@ -43,6 +43,6 @@ import "BasicTypes.proto";
 message TokenWipeAccountTransactionBody {
     TokenID token = 1; // The token for which the account will be wiped. If token does not exist, transaction results in INVALID_TOKEN_ID
     AccountID account = 2; // The account to be wiped
-    uint64 amount = 3; // Applicable to tokens of type FUNGIBLE_COMMON. The amount of tokens to wipe from the specified account. Amount must be a positive non-zero number in the lowest denomination possible, not bigger than the token balance of the account (0; balance]
+    int64 amount = 3; // Applicable to tokens of type FUNGIBLE_COMMON. The amount of tokens to wipe from the specified account. Amount must be a positive non-zero number in the lowest denomination possible, not bigger than the token balance of the account (0; balance]
     repeated int64 serialNumbers = 4; // Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be wiped.
 }

--- a/services/TransactionBody.proto
+++ b/services/TransactionBody.proto
@@ -77,7 +77,7 @@ import "ScheduleSign.proto";
 message TransactionBody {
   TransactionID transactionID = 1; // The ID for this transaction, which includes the payer's account (the account paying the transaction fee). If two transactions have the same transactionID, they won't both have an effect
   AccountID nodeAccountID = 2; // The account of the node that submits the client's transaction to the network
-  uint64 transactionFee = 3; // The maximum transaction fee the client is willing to pay
+  int64 transactionFee = 3; // The maximum transaction fee the client is willing to pay
   Duration transactionValidDuration = 4; //The transaction is invalid if consensusTimestamp > transactionID.transactionValidStart + transactionValidDuration
   bool generateRecord = 5 [deprecated = true]; // Should a record of this transaction be generated? (A receipt is always generated, but the record is optional)
   string memo = 6; // Any notes or descriptions that should be put into the record (max length 100)

--- a/services/TransactionReceipt.proto
+++ b/services/TransactionReceipt.proto
@@ -49,7 +49,7 @@ message TransactionReceipt {
     TopicID topicID = 6;
 
     // In the receipt of a ConsensusSubmitMessage, the new sequence number of the topic that received the message
-    uint64 topicSequenceNumber = 7;
+    int64 topicSequenceNumber = 7;
 
     // In the receipt of a ConsensusSubmitMessage, the new running hash of the topic that received the message.
     // This 48-byte field is the output of a particular SHA-384 digest whose input data are determined by the
@@ -96,13 +96,13 @@ message TransactionReceipt {
     bytes topicRunningHash = 8;
 
     // In the receipt of a ConsensusSubmitMessage, the version of the SHA-384 digest used to update the running hash.
-    uint64 topicRunningHashVersion = 9;
+    int64 topicRunningHashVersion = 9;
 
     // In the receipt of a CreateToken, the id of the newly created token
     TokenID tokenID = 10;
 
     // In the receipt of TokenMint, TokenWipe, TokenBurn, the current total supply of this token
-    uint64 newTotalSupply = 11;
+    int64 newTotalSupply = 11;
 
     // In the receipt of a ScheduleCreate, the id of the newly created Scheduled Entity
     ScheduleID scheduleID = 12;

--- a/services/TransactionRecord.proto
+++ b/services/TransactionRecord.proto
@@ -38,7 +38,7 @@ message TransactionRecord {
     Timestamp consensusTimestamp = 3; // The consensus timestamp (or null if didn't reach consensus yet)
     TransactionID transactionID = 4; // The ID of the transaction this record represents
     string memo = 5; // The memo that was submitted as part of the transaction (max 100 bytes)
-    uint64 transactionFee = 6; // The actual transaction fee charged, not the original transactionFee value from TransactionBody
+    int64 transactionFee = 6; // The actual transaction fee charged, not the original transactionFee value from TransactionBody
     oneof body {
         ContractFunctionResult contractCallResult = 7; // Record of the value returned by the smart contract function (if it completed and didn't fail) from ContractCallTransaction
         ContractFunctionResult contractCreateResult = 8; // Record of the value returned by the smart contract constructor (if it completed and didn't fail) from ContractCreateTransaction

--- a/services/TransactionResponse.proto
+++ b/services/TransactionResponse.proto
@@ -31,5 +31,5 @@ import "ResponseCode.proto";
 /* When the client sends the node a transaction of any kind, the node replies with this, which simply says that the transaction passed the precheck (so the node will submit it to the network) or it failed (so it won't). If the fee offered was insufficient, this will also contain the amount of the required fee. To learn the consensus result, the client should later obtain a receipt (free), or can buy a more detailed record (not free). */
 message TransactionResponse {
 	ResponseCodeEnum nodeTransactionPrecheckCode = 1; // The response code that indicates the current status of the transaction.
-	uint64 cost = 2; // If the response code was INSUFFICIENT_TX_FEE, the actual transaction fee that would be required to execute the transaction.
+	int64 cost = 2; // If the response code was INSUFFICIENT_TX_FEE, the actual transaction fee that would be required to execute the transaction.
 }

--- a/streams/AccountBalanceFile.proto
+++ b/streams/AccountBalanceFile.proto
@@ -30,13 +30,13 @@ import "Timestamp.proto";
 
 message TokenUnitBalance {
     TokenID tokenId = 1; // A unique token id
-    uint64 balance = 2; // Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON - balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
+    int64 balance = 2; // Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON - balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
 }
 
 /* Includes all currency balances (both hbar and token) of a single account in the ledger. */
 message SingleAccountBalances {
     AccountID accountID = 1; // The account
-    uint64 hbarBalance = 2; // The account's hbar balance
+    int64 hbarBalance = 2; // The account's hbar balance
     repeated TokenUnitBalance tokenUnitBalances = 3; // The list of the account's token balances
 }
 


### PR DESCRIPTION
Signed-off-by: Georgi Georgiev <georgi.getz@outlook.com>

**Description**:
This PR is the first of several to be parallelly merged fixing the misalignment of types between the protobuf files and the contracts and it also includes replacement of all uints in the protobuf files. The reason the uints are a problem is because they are ultimately being converted to a signed type regardless and the upper half of their values is unusable. 
![image](https://user-images.githubusercontent.com/22292075/192523437-10250823-efc1-4620-991c-dba87204ba3d.png)
Part of the work in the other repos depends on feedback given to this PR.

**Related issue(s)**:

Fixes hashgraph/hedera-services#3921
hashgraph/hedera-services#3916

**Notes for reviewer**:
This PR won't be merged until the necessary follow-up PRs in the contracts/docs/services/sdk repos have all been opened and approved as well. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
