### PR TITLE
03916 remove uints

### DIFF
--- a/mirror/consensus_service.proto
+++ b/mirror/consensus_service.proto
@@ -55,7 +55,7 @@ message ConsensusTopicQuery {
      * The maximum number of messages to receive before stopping. If not set or set to zero it will
      * return messages indefinitely.
      */
-    uint64 limit = 4;
+    int64 limit = 4;
 }
 
 message ConsensusTopicResponse {
@@ -78,12 +78,12 @@ message ConsensusTopicResponse {
     /**
      * Starts at 1 for first submitted message. Incremented on each submitted message.
      */
-    uint64 sequenceNumber = 4;
+    int64 sequenceNumber = 4;
 
     /**
      * Version of the SHA-384 digest used to update the running hash.
      */
-    uint64 runningHashVersion = 5;
+    int64 runningHashVersion = 5;
 
     /**
      * Optional information of the current chunk in a fragmented message.

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -309,7 +309,7 @@ message TokenTransferList {
      * If present, the number of decimals this fungible token type is expected to have. The transfer
      * will fail with UNEXPECTED_TOKEN_DECIMALS if the actual decimals differ.
      */
-    google.protobuf.UInt32Value expected_decimals = 4;
+    google.protobuf.Int32Value expected_decimals = 4;
 }
 
 /**
@@ -631,7 +631,7 @@ message ThresholdKey {
     /**
      * A valid signature set must have at least this many signatures
      */
-    uint32 threshold = 1;
+    int32 threshold = 1;
 
     /**
      * List of all the keys that can sign
@@ -1480,7 +1480,7 @@ message TokenRelationship {
      * For token of type FUNGIBLE_COMMON - the balance that the Account holds in the smallest
      * denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
      */
-    uint64 balance = 3;
+    int64 balance = 3;
 
     /**
      * The KYC status of the account (KycNotApplicable, Granted or Revoked). If the token does not
@@ -1497,7 +1497,7 @@ message TokenRelationship {
     /**
      * Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
      */
-    uint32 decimals = 6;
+    int32 decimals = 6;
 
     /**
      * Specifies if the relationship is created implicitly. False : explicitly associated, True :
@@ -1528,12 +1528,12 @@ message TokenBalance {
      * balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of
      * NFTs held by the account
      */
-    uint64 balance = 2;
+    int64 balance = 2;
 
     /**
      * Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
      */
-    uint32 decimals = 3;
+    int32 decimals = 3;
 }
 
 /**

--- a/services/consensus_topic_info.proto
+++ b/services/consensus_topic_info.proto
@@ -52,7 +52,7 @@ message ConsensusTopicInfo {
     /**
      * Sequence number (starting at 1 for the first submitMessage) of messages on the topic.
      */
-    uint64 sequenceNumber = 3;
+    int64 sequenceNumber = 3;
 
     /**
      * Effective consensus timestamp at (and after) which submitMessage calls will no longer succeed on the topic

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -87,7 +87,7 @@ message ContractFunctionResult {
     /**
      * units of gas used to execute contract
      */
-    uint64 gasUsed = 5;
+    int64 gasUsed = 5;
 
     /**
      * the log info for events returned by the function

--- a/services/contract_get_info.proto
+++ b/services/contract_get_info.proto
@@ -112,7 +112,7 @@ message ContractGetInfoResponse {
         /**
          * The current balance, in tinybars
          */
-        uint64 balance = 9;
+        int64 balance = 9;
 
         /**
          * Whether the contract has been deleted

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -69,7 +69,7 @@ message CryptoCreateTransactionBody {
     /**
      * The initial number of tinybars to put into the account
      */
-    uint64 initialBalance = 2;
+    int64 initialBalance = 2;
 
     /**
      * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an

--- a/services/crypto_get_account_balance.proto
+++ b/services/crypto_get_account_balance.proto
@@ -73,7 +73,7 @@ message CryptoGetAccountBalanceResponse {
     /**
      * The current balance, in tinybars.
      */
-    uint64 balance = 3;
+    int64 balance = 3;
 
     /**
      * [DEPRECATED] The balances of the tokens associated to the account. This field was 

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -101,7 +101,7 @@ message CryptoGetInfoResponse {
         /**
          * The current balance of account in tinybars
          */
-        uint64 balance = 8;
+        int64 balance = 8;
 
         /**
          * [Deprecated]. The threshold amount, in tinybars, at which a record is created of any

--- a/services/get_account_details.proto
+++ b/services/get_account_details.proto
@@ -101,7 +101,7 @@ message GetAccountDetailsResponse {
         /**
          * The current balance of account in tinybars
          */
-        uint64 balance = 7;
+        int64 balance = 7;
 
         /**
          * If true, no transaction can transfer to this account unless signed by this account's key

--- a/services/network_get_execution_time.proto
+++ b/services/network_get_execution_time.proto
@@ -63,5 +63,5 @@ message NetworkGetExecutionTimeResponse {
     /**
      * The execution time(s) of the requested TransactionIDs, if available
      */
-    repeated uint64 execution_times = 2;
+    repeated int64 execution_times = 2;
 }

--- a/services/response_header.proto
+++ b/services/response_header.proto
@@ -46,11 +46,11 @@ message ResponseHeader {
 
     /**
      * The fee that would be charged to get the requested information (if a cost was requested).
-     * Note: This cost only includes the query fee and does not include the transfer fee(which is
+     * Note: This cost only includes the query fee and does not include the transfer fee (which is
      * required to execute the transfer transaction to debit the payer account and credit the node
      * account with query fee)
      */
-    uint64 cost = 3;
+    int64 cost = 3;
 
     /**
      * The state proof for this information (if a state proof was requested, and is available)

--- a/services/schedulable_transaction_body.proto
+++ b/services/schedulable_transaction_body.proto
@@ -81,7 +81,7 @@ message SchedulableTransactionBody {
   /**
    * The maximum transaction fee the client is willing to pay
    */
-  uint64 transactionFee = 1;
+  int64 transactionFee = 1;
 
   /**
    * A memo to include the execution record; the UTF-8 encoding may be up to 100 bytes and must not

--- a/services/throttle_definitions.proto
+++ b/services/throttle_definitions.proto
@@ -47,7 +47,7 @@ message ThrottleGroup {
    * second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use
    * milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
    */
-  uint64 milliOpsPerSec = 2;
+  int32 milliOpsPerSec = 2;
 }
 
 /**
@@ -64,7 +64,7 @@ message ThrottleBucket {
    * of this number and the least common multiple of the milliOpsPerSec values in this bucket must
    * not exceed 9223372036.
    */
-  uint64 burstPeriodMs = 2;
+  int64 burstPeriodMs = 2;
 
   /**
    * The throttle groups competing for this bucket

--- a/services/token_burn.proto
+++ b/services/token_burn.proto
@@ -57,7 +57,7 @@ message TokenBurnTransactionBody {
      * Amount must be a positive non-zero number, not bigger than the token balance of the treasury
      * account (0; balance], represented in the lowest denomination.
      */
-    uint64 amount = 2;
+    int64 amount = 2;
 
     /**
      * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be burned.

--- a/services/token_create.proto
+++ b/services/token_create.proto
@@ -89,7 +89,7 @@ message TokenCreateTransactionBody {
      * token is divisible by. For tokens of type NON_FUNGIBLE_UNIQUE - value
      * must be 0
      */
-    uint32 decimals = 3;
+    int32 decimals = 3;
 
     /**
      * Specifies the initial supply of tokens to be put in circulation. The
@@ -97,7 +97,7 @@ message TokenCreateTransactionBody {
      * lowest denomination possible. In the case for NON_FUNGIBLE_UNIQUE Type
      * the value must be 0
      */
-    uint64 initialSupply = 4;
+    int64 initialSupply = 4;
 
     /**
      * The account which will act as a treasury for the token. This account

--- a/services/token_get_info.proto
+++ b/services/token_get_info.proto
@@ -72,14 +72,14 @@ message TokenInfo {
      * The number of decimal places a token is divisible by. Always 0 for tokens of type
      * NON_FUNGIBLE_UNIQUE
      */
-    uint32 decimals = 4;
+    int32 decimals = 4;
 
     /**
      * For tokens of type FUNGIBLE_COMMON - the total supply of tokens that are currently in
      * circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the number of NFTs created of this
      * token instance
      */
-    uint64 totalSupply = 5;
+    int64 totalSupply = 5;
 
     /**
      * The ID of the account which is set as Treasury

--- a/services/token_mint.proto
+++ b/services/token_mint.proto
@@ -56,7 +56,7 @@ message TokenMintTransactionBody {
      * Amount must be a positive non-zero number represented in the lowest denomination of the
      * token. The new supply must be lower than 2^63.
      */
-    uint64 amount = 2;
+    int64 amount = 2;
 
     /**
      * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. A list of metadata that are being created.

--- a/services/token_wipe_account.proto
+++ b/services/token_wipe_account.proto
@@ -72,7 +72,7 @@ message TokenWipeAccountTransactionBody {
      * account. Amount must be a positive non-zero number in the lowest denomination possible, not
      * bigger than the token balance of the account (0; balance]
      */
-    uint64 amount = 3;
+    int64 amount = 3;
 
     /**
      * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be wiped.

--- a/services/transaction_body.proto
+++ b/services/transaction_body.proto
@@ -102,7 +102,7 @@ message TransactionBody {
   /**
    * The maximum transaction fee the client is willing to pay
    */
-  uint64 transactionFee = 3;
+  int64 transactionFee = 3;
 
   /**
    * The transaction is invalid if consensusTimestamp > transactionID.transactionValidStart +

--- a/services/transaction_receipt.proto
+++ b/services/transaction_receipt.proto
@@ -69,7 +69,7 @@ message TransactionReceipt {
      * In the receipt of a ConsensusSubmitMessage, the new sequence number of the topic that
      * received the message
      */
-    uint64 topicSequenceNumber = 7;
+    int64 topicSequenceNumber = 7;
 
     /**
      * In the receipt of a ConsensusSubmitMessage, the new running hash of the topic that received
@@ -132,7 +132,7 @@ message TransactionReceipt {
      * In the receipt of a ConsensusSubmitMessage, the version of the SHA-384 digest used to update
      * the running hash.
      */
-    uint64 topicRunningHashVersion = 9;
+    int64 topicRunningHashVersion = 9;
 
     /**
      * In the receipt of a CreateToken, the id of the newly created token
@@ -144,7 +144,7 @@ message TransactionReceipt {
      * supply of this token. For non fungible tokens - the total number of NFTs issued for a given
      * tokenID
      */
-    uint64 newTotalSupply = 11;
+    int64 newTotalSupply = 11;
 
     /**
      * In the receipt of a ScheduleCreate, the id of the newly created Scheduled Entity

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -67,7 +67,7 @@ message TransactionRecord {
      * The actual transaction fee charged, not the original transactionFee value from
      * TransactionBody
      */
-    uint64 transactionFee = 6;
+    int64 transactionFee = 6;
 
     oneof body {
         /**

--- a/services/transaction_response.proto
+++ b/services/transaction_response.proto
@@ -45,5 +45,5 @@ message TransactionResponse {
      * If the response code was INSUFFICIENT_TX_FEE, the actual transaction fee that would be
      * required to execute the transaction.
 	 */
-	uint64 cost = 2;
+	int64 cost = 2;
 }

--- a/streams/account_balance_file.proto
+++ b/streams/account_balance_file.proto
@@ -39,7 +39,7 @@ message TokenUnitBalance {
      * balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of
      * NFTs held by the account
      */
-    uint64 balance = 2;
+    int64 balance = 2;
 }
 
 /**
@@ -54,7 +54,7 @@ message SingleAccountBalances {
     /**
      * The account's hbar balance
      */
-    uint64 hbarBalance = 2;
+    int64 hbarBalance = 2;
 
     /**
      * The list of the account's token balances


### PR DESCRIPTION
Signed-off-by: Georgi Georgiev <georgi.getz@outlook.com>

**Description**:
This PR is the first of several to be parallelly merged fixing the misalignment of types between the protobuf files and the contracts and it also includes replacement of all uints in the protobuf files. The reason the uints are a problem is because they are ultimately being converted to a signed type regardless and the upper half of their values is unusable. 
![image](https://user-images.githubusercontent.com/22292075/192523437-10250823-efc1-4620-991c-dba87204ba3d.png)
Part of the work in the other repos depends on feedback given to this PR.

**Related issue(s)**:

Fixes hashgraph/hedera-services#3921
hashgraph/hedera-services#3916

**Notes for reviewer**:
This PR won't be merged until the necessary follow-up PRs in the contracts/docs/services/sdk repos have all been opened and approved as well.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)