### PR TITLE
Add new fields for externalizing account alias

### DIFF
--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -188,10 +188,26 @@ message CryptoGetInfoResponse {
          * cover auto-renewal fees.
          */
         AccountID auto_renew_account = 23;
+
+        repeated VirtualAddress virtualAddresses = 24;
+
+        bytes defaultVirtualAddress = 25;
     }
 
     /**
      * Info about the account (a state proof can be generated for this)
      */
     AccountInfo accountInfo = 2;
+}
+
+message VirtualAddress {
+    /**
+     * The 20-byte EVM address
+     */
+    bytes virtualAddress = 1;
+
+    /**
+     * The ethereum transaction nonce associated with this address.
+     */
+    int64 nonce = 2;
 }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -29,6 +29,7 @@ import "basic_types.proto";
 import "duration.proto";
 import "timestamp.proto";
 import "google/protobuf/wrappers.proto";
+import "transaction_record.proto";
 
 /**
  * Change properties for the given account. Any null field is ignored (left unchanged). This
@@ -160,4 +161,6 @@ message CryptoUpdateTransactionBody {
      * account. Otherwise it updates the account's auto-renew account to the referenced account.
      */
     AccountID auto_renew_account = 19;
+
+    VirtualAddressUpdate virtualAddressUpdate = 20;
 }

--- a/services/transaction_record.proto
+++ b/services/transaction_record.proto
@@ -145,4 +145,28 @@ message TransactionRecord {
          */
         int32 prng_number = 20;
     }
+
+   /**
+    * Virtual address updated info. At most one update can be performed at a time.
+    */
+    VirtualAddressUpdate virtualAddressUpdate = 21;
+}
+
+message VirtualAddressUpdate {
+    /**
+     * A 20-byte EVM address account identifier. This is the keccak-256 hash of a ECDSA_SECP256K1 primitive key.
+     *
+     * At most one account can ever have a given evm address
+     */
+    bytes evmAddress = 1;
+
+    /**
+     * Flag if this address is being added
+     */
+    bool addition = 2;
+
+    /**
+     * Flag if this address should now be set or is the default address on the account
+     */
+    bool isDefaultAddress = 3;
 }


### PR DESCRIPTION
Signed-off-by: Miroslav Gatsanoga <miroslav.gatsanoga@limechain.tech>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Creating accounts with EC keys can result in an EVM public address alias being tracked by the consensus nodes. This alias should be externalized so that mirror nodes have that information.

**Related issue(s)**:

- Fixes: https://github.com/hashgraph/hedera-protobufs/issues/241
- https://github.com/hashgraph/hedera-services/issues/4146


