### PR TITLE
Add virtual_address_update disable

### DIFF
--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -167,17 +167,8 @@ message CryptoUpdateTransactionBody {
     oneof virtual_address_update {
         /**
          * The virtual address to be added.
+         * The address one successfully addition becomes par tof the accounts ACTIVE virtual addresses
          */
         VirtualAddress add = 20;
-
-        /**
-        * The 20-byte EVM address of the virtual address that is being disabled and therefore removed from active use on the account.
-        */
-        bytes disable = 21;
-        
-        /**
-        * The 20-byte EVM address of the virtual address that is being removed from the account.
-        */
-        bytes remove = 22;
     }
 }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -171,8 +171,13 @@ message CryptoUpdateTransactionBody {
         VirtualAddress add = 20;
 
         /**
-         * The 20-byte EVM address of the virtual address that is being removed.
-         */
-        bytes remove = 21;
+        * The 20-byte EVM address of the virtual address that is being disabled and therefore removed from active use on the account.
+        */
+        bytes disable = 21;
+        
+        /**
+        * The 20-byte EVM address of the virtual address that is being removed from the account.
+        */
+        bytes remove = 22;
     }
 }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -167,7 +167,7 @@ message CryptoUpdateTransactionBody {
     oneof virtual_address_update {
         /**
          * The virtual address to be added.
-         * The address one successfully addition becomes par tof the accounts ACTIVE virtual addresses
+         * The address one successfully addition becomes part of the accounts ACTIVE virtual addresses
          */
         VirtualAddress add = 20;
     }

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -167,7 +167,7 @@ message CryptoUpdateTransactionBody {
     oneof virtual_address_update {
         /**
          * The virtual address to be added.
-         * The address one successfully addition becomes part of the accounts ACTIVE virtual addresses
+         * Once successfully added, the address becomes part of the account's ACTIVE virtual addresses.
          */
         VirtualAddress add = 20;
     }


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
To support the ability to disable a virtual address but keep it associated with an account
- add `disable` to `CryptoUpdateTransactionBody.virtual_address_update`

**Related issue(s)**:

Fixes #248 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
