### PR TITLE
Add additional costs field in `EthereumTransactionBody`

### DIFF
--- a/services/ethereum_transaction.proto
+++ b/services/ethereum_transaction.proto
@@ -60,4 +60,12 @@ message EthereumTransactionBody {
    * the entire fee.
    */
   int64 max_gas_allowance = 3;
+
+  /**
+   * The maximum amount, in tinybars, that the payer of the Hedera transaction
+   * is willing to pay to for any additional *non-gas* costs of the transaction.
+   *
+   * An example of such costs would be any hollow account creation fees.
+   */
+  int64 max_additional_costs_allowance = 4;
 }

--- a/services/ethereum_transaction.proto
+++ b/services/ethereum_transaction.proto
@@ -63,9 +63,9 @@ message EthereumTransactionBody {
 
   /**
    * The maximum amount, in tinybars, that the payer of the Hedera transaction
-   * is willing to pay to for any additional *non-gas* costs of the transaction.
+   * is willing to pay for any additional *non-gas* costs of the transaction.
    *
    * An example of such costs would be any hollow account creation fees.
    */
-  int64 max_additional_costs_allowance = 4;
+  int64 max_additional_fee_allowance = 4;
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Adds a `max_additional_costs_allowance` field to `EthereumTransactionBody`.

**Related issue(s)**:

Fixes #254 

