### PR TITLE
Change allowance maps on `Account` PBJ Object

### DIFF
--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -159,16 +159,16 @@ message Account {
     /**
      * (Optional) List of crypto allowances approved by the account.
      */
-    repeated CryptoAllowance crypto_allowances = 27;
+    map<int64, int64> crypto_allowances = 27;
     /**
      * (Optional) List of non-fungible token allowances approved by the account.
      */
-    repeated NftAllowance nft_allowances = 28;
+    repeated TokenAllowance approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
      */
-    repeated TokenAllowance token_allowances = 29;
+    repeated FungibleTokenAllowances token_allowances = 29;
     /**
      * The number of tokens for which this account is treasury
      */
@@ -182,4 +182,14 @@ message Account {
      * and the time the system task actually auto-renews it.
      */
     bool expired_and_pending_removal = 31;
+}
+
+message FungibleTokenAllowances {
+    TokenAllowance token_allowance_key = 1;
+    int64 amount = 2;
+}
+
+message TokenAllowance {
+    int64 token_id = 1;
+    int64 account_id = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -186,8 +186,8 @@ message Account {
 }
 
 message AccountTokenAllowance {
-    int64 token_id = 1;
-    int64 account_id = 2;
+    int64 token_num = 1;
+    int64 account_num = 2;
 }
 
 message AccountFungibleTokenAllowance {
@@ -196,6 +196,6 @@ message AccountFungibleTokenAllowance {
 }
 
 message AccountCryptoAllowance {
-    int64 account_id = 1;
+    int64 account_num = 1;
     int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -160,16 +160,16 @@ message Account {
      * (Optional) Map of crypto allowances approved by the account.
      * Key is the account number and value is the amount approved for that account.
      */
-    map<int64, int64> crypto_allowances = 27;
+    repeated AccountCryptoAllowances crypto_allowances = 27;
     /**
      * (Optional) List of non-fungible token allowances approved by the account.
      */
-    repeated TokenAllowancesId approve_for_all_nft_allowances = 28;
+    repeated AccountTokenAllowance approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
      */
-    repeated FungibleTokenAllowances token_allowances = 29;
+    repeated AccountFungibleTokenAllowances token_allowances = 29;
     /**
      * The number of tokens for which this account is treasury
      */
@@ -185,12 +185,17 @@ message Account {
     bool expired_and_pending_removal = 31;
 }
 
-message TokenAllowancesId {
+message AccountTokenAllowance {
     int64 token_id = 1;
     int64 account_id = 2;
 }
 
-message FungibleTokenAllowances {
-    TokenAllowancesId token_allowance_key = 1;
+message AccountFungibleTokenAllowances {
+    AccountTokenAllowance token_allowance_key = 1;
+    int64 amount = 2;
+}
+
+message AccountCryptoAllowances {
+    int64 account_id = 1;
     int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -157,17 +157,23 @@ message Account {
      */
     int32 contract_kv_pairs_number = 26;
     /**
-     * (Optional) Map of crypto allowances approved by the account.
-     * Key is the account number and value is the amount approved for that account.
+     * (Optional) List of crypto allowances approved by the account.
+     * It contains account number for which the allowance is approved to and
+     * the amount approved for that account.
      */
     repeated AccountCryptoAllowance crypto_allowances = 27;
     /**
-     * (Optional) List of non-fungible token allowances approved by the account.
+     * (Optional) List of non-fungible token allowances approved for all by the account.
+     * It contains account number approved for spending all serial numbers for the given
+     * NFT token number using approved_for_all flag.
+     * Allowances for a specific serial number is stored in the NFT itself in state.
      */
     repeated AccountTokenAllowance approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
+     * It contains account number for which the allowance is approved to and  the token number.
+     * It also contains and the amount approved for that account.
      */
     repeated AccountFungibleTokenAllowance token_allowances = 29;
     /**
@@ -185,16 +191,26 @@ message Account {
     bool expired_and_pending_removal = 31;
 }
 
+/**
+ * Allowance granted by this account to another account for a specific token.
+ */
 message AccountTokenAllowance {
     int64 token_num = 1;
     int64 account_num = 2;
 }
 
+/**
+ * Allowance granted by this account to another account for a specific fungible token.
+ * This also contains the amount of the token that is approved for the account.
+ */
 message AccountFungibleTokenAllowance {
     AccountTokenAllowance token_allowance_key = 1;
     int64 amount = 2;
 }
 
+/**
+ * Allowance granted by this account to another account for an amount of hbars.
+ */
 message AccountCryptoAllowance {
     int64 account_num = 1;
     int64 amount = 2;

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -160,7 +160,7 @@ message Account {
      * (Optional) Map of crypto allowances approved by the account.
      * Key is the account number and value is the amount approved for that account.
      */
-    repeated AccountCryptoAllowances crypto_allowances = 27;
+    repeated AccountCryptoAllowance crypto_allowances = 27;
     /**
      * (Optional) List of non-fungible token allowances approved by the account.
      */
@@ -169,7 +169,7 @@ message Account {
     /**
      * (Optional) List of fungible token allowances approved by the account.
      */
-    repeated AccountFungibleTokenAllowances token_allowances = 29;
+    repeated AccountFungibleTokenAllowance token_allowances = 29;
     /**
      * The number of tokens for which this account is treasury
      */
@@ -190,12 +190,12 @@ message AccountTokenAllowance {
     int64 account_id = 2;
 }
 
-message AccountFungibleTokenAllowances {
+message AccountFungibleTokenAllowance {
     AccountTokenAllowance token_allowance_key = 1;
     int64 amount = 2;
 }
 
-message AccountCryptoAllowances {
+message AccountCryptoAllowance {
     int64 account_id = 1;
     int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -157,13 +157,14 @@ message Account {
      */
     int32 contract_kv_pairs_number = 26;
     /**
-     * (Optional) List of crypto allowances approved by the account.
+     * (Optional) Map of crypto allowances approved by the account.
+     * Key is the account number and value is the amount approved for that account.
      */
     map<int64, int64> crypto_allowances = 27;
     /**
      * (Optional) List of non-fungible token allowances approved by the account.
      */
-    repeated TokenAllowance approve_for_all_nft_allowances = 28;
+    repeated TokenAllowancesId approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
@@ -184,12 +185,12 @@ message Account {
     bool expired_and_pending_removal = 31;
 }
 
-message FungibleTokenAllowances {
-    TokenAllowance token_allowance_key = 1;
-    int64 amount = 2;
-}
-
-message TokenAllowance {
+message TokenAllowancesId {
     int64 token_id = 1;
     int64 account_id = 2;
+}
+
+message FungibleTokenAllowances {
+    TokenAllowancesId token_allowance_key = 1;
+    int64 amount = 2;
 }


### PR DESCRIPTION
Since `Owner` field is not required for the allowances map on a specific account, added new messages without `Owner` field in `Account` PBJ Object for state.