### PR TITLE
Fix package name for state/schedule

### DIFF
--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
- * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";
@@ -27,7 +27,7 @@ import "timestamp.proto";
 import "schedulable_transaction_body.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
-// <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
+// <<<pbj.java_package = "com.hedera.hapi.node.state.schedule">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**


### PR DESCRIPTION
Original commit of this file uses package com.hedera.hapi.node.state.file.
The correct package is com.hedera.hapi.node.state.schedule.

Verified clean build in services with [verify-protos](https://github.com/jsync-swirlds/bash-scripts/blob/swirlds/verify-protos) script.