### PR TITLE
Update file.proto to use FileID type instead of long for file identification

### DIFF
--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -51,9 +51,9 @@ option java_multiple_files = true;
  */
 message Topic {
     /**
-     * The topic's unique entity number in the Merkle state.
+     * The topic's unique id number in the Merkle state.
      */
-    int64 topic_number = 1;
+    TopicID id = 1;
     /**
      * The number of messages sent to the topic.
      */

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -37,10 +37,9 @@ option java_multiple_files = true;
  */
 message File {
     /**
-     * DEPRECATED and replaced by file_id.
-     * The file's unique entity number in the Merkle state.
+     * The file's unique file identifier in the Merkle state.
      */
-    int64 file_number = 1 [deprecated=true];
+    FileID file_id = 1;
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
@@ -61,8 +60,4 @@ message File {
      * Whether this file is deleted.
      */
     bool deleted = 6;
-    /**
-     * The file's unique file identifier in the Merkle state.
-     */
-    FileID file_id = 7;
 }

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -37,9 +37,10 @@ option java_multiple_files = true;
  */
 message File {
     /**
+     * DEPRECATED and replaced by file_id.
      * The file's unique entity number in the Merkle state.
      */
-    int64 file_number = 1;
+    int64 file_number = 1 [deprecated=true];
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
@@ -60,4 +61,8 @@ message File {
      * Whether this file is deleted.
      */
     bool deleted = 6;
+    /**
+     * The file's unique file identifier in the Merkle state.
+     */
+    FileID file_id = 7;
 }


### PR DESCRIPTION
Change `long file_number` to `FileID file_id` in file.proto

**Related issue(s)**:

This is in support of [issue #7098 in the hedera-services repo](https://github.com/hashgraph/hedera-services/issues/7098)

**Notes for reviewer**:

`file.proto` is not part of any previous releases. Therefore there is no need to ensure backwards compatibility.