### PR TITLE
Change nft owner and spender identifier from long to AccountID

### DIFF
--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -23,6 +23,7 @@ package proto;
  */
 
 import "timestamp.proto";
+import "basic_types.proto";
 import "state/common.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -39,19 +39,20 @@ message Nft {
      */
     UniqueTokenId id = 1;
 
+
     /**
-     * The number of the account or contract that owns this NFT. 
+     * The account or contract id that owns this NFT.
      *
      * If this number is zero in state, the NFT is owned by its token type's current treasury.
      */
-    int64 owner_number = 2;
+    AccountID owner_id = 2;
 
     /**
-     * The number of the account or contract approved to spend this NFT.
-     * 
+     * The account or contract id approved to spend this NFT.
+     *
      * If this number is zero, there is no approved spender.
      */
-    int64 spender_number = 3;
+    AccountID spender_id = 3;
 
     /**
      * The consensus time of the TokenMint that created this NFT.


### PR DESCRIPTION
Use IDs instead of longs for types in nft.proto

**Related issue(s)**:

Fixes # 7244 in hedera-services repo
See [PR #7288](https://github.com/hashgraph/hedera-services/pull/7288) over in hedera-services 

DO NOT MERGE THIS PR UNTIL AFTER [PR #7288](https://github.com/hashgraph/hedera-services/pull/7288) HAS BEEN MERGED

