### PR TITLE
Use NftID instead of UniqueTokenId

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -114,6 +114,21 @@ message AccountID {
 }
 
 /**
+ * Represents an NFT on the Ledger
+ */
+message NftID {
+    /**
+     * The (non-fungible) token of which this NFT is an instance
+     */
+    TokenID tokenID = 1;
+
+    /**
+     * The unique identifier of this instance
+     */
+    int64 serialNumber = 2;
+}
+
+/**
  * The ID for a file 
  */
 message FileID {

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -114,18 +114,18 @@ message AccountID {
 }
 
 /**
- * Represents an NFT on the Ledger
+ * Identifier for a unique token (or "NFT"), used by both contract and token services.
  */
 message NftID {
     /**
      * The (non-fungible) token of which this NFT is an instance
      */
-    TokenID tokenID = 1;
+    TokenID token_id = 1;
 
     /**
-     * The unique identifier of this instance
+     * The serial number of this NFT within its token type
      */
-    int64 serialNumber = 2;
+    int64 serial_number = 2;
 }
 
 /**

--- a/services/state/common.proto
+++ b/services/state/common.proto
@@ -41,18 +41,3 @@ message EntityIDPair {
   AccountID account_id = 1;
   TokenID token_id = 2;
 }
-
-/**
- * Identifier for a unique token (or "NFT"), used by both contract and token services.
- */
-message UniqueTokenId {
-  /**
-   * The id of the unique token type this NFT is an instance of.
-   */
-  TokenID token_id = 1;
-
-  /**
-   * The serial number of this NFT within its token type.
-   */
-  int64 serial_number = 2;
-}

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -97,11 +97,11 @@ message Account {
      */
     int64 head_token_number = 13;
     /**
-     * The NftId of the head of the linked list from unique tokens map for the account.
+     * The NftID of the head of the linked list from unique tokens map for the account.
      */
     int64 head_nft_id = 14;
     /**
-      * The serial number of the head NftId of the linked list from unique tokens map for the account.
+      * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
     int64 head_nft_serial_number = 15;
     /**

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -24,7 +24,6 @@ package proto;
 
 import "timestamp.proto";
 import "basic_types.proto";
-import "state/common.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
@@ -38,8 +37,7 @@ message Nft {
     /**
      * The id of this NFT.
      */
-    UniqueTokenId id = 1;
-
+    NftID id = 1;
 
     /**
      * The account or contract id that owns this NFT.
@@ -69,11 +67,11 @@ message Nft {
      * If the owner of this NFT is not its token treasury, the id of the previous NFT 
      * in the owner's "doubly-linked list" of owned NFTs (if any).
      */
-    UniqueTokenId owner_previous_nft_id = 6;
+    NftID owner_previous_nft_id = 6;
 
     /**
      * If the owner of this NFT is not its token treasury, the id of the next NFT in 
      * the owner's "doubly-linked list" of owned NFTs (if any).
      */
-    UniqueTokenId owner_next_nft_id = 7;
+    NftID owner_next_nft_id = 7;
 }

--- a/services/token_get_nft_info.proto
+++ b/services/token_get_nft_info.proto
@@ -32,21 +32,6 @@ import "response_header.proto";
 import "timestamp.proto";
 
 /**
- * Represents an NFT on the Ledger
- */
-message NftID {
-    /**
-     * The (non-fungible) token of which this NFT is an instance
-     */
-    TokenID tokenID = 1;
-
-    /**
-     * The unique identifier of this instance
-     */
-    int64 serialNumber = 2;
-}
-
-/**
  * Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on a NFT for a given TokenID (of
  * type NON_FUNGIBLE_UNIQUE) and serial number
  */


### PR DESCRIPTION
**Description**:
1) Move NftID from token_get_nft_info.proto to basic_types.proto
2) Change everywhere that uses UniqueTokenID to use NftID instead
3) Delete UniqueTokenId from common.proto

**Related issue(s)**:
Fixes [#7346 in hedera-services](https://github.com/hashgraph/hedera-services/issues/7346)

**Note**:
DO NOT MERGE UNTIL AFTER [PR # 7409](https://github.com/hashgraph/hedera-services/pull/7409) has been merged