### PR TITLE
protobuf cleanup

### DIFF
--- a/services/crypto_get_account_balance.proto
+++ b/services/crypto_get_account_balance.proto
@@ -29,7 +29,6 @@ option java_multiple_files = true;
 import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
-import "timestamp.proto";
 
 /**
  * Get the balance of a cryptocurrency account. This returns only the balance, so it is a smaller

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -31,8 +31,6 @@ import "duration.proto";
 import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
-import "crypto_add_live_hash.proto";
-import "google/protobuf/wrappers.proto";
 
 /**
  * Get all the information about an account, including the balance. This does not get the list of

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -31,6 +31,7 @@ import "duration.proto";
 import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
+import "crypto_add_live_hash.proto";
 
 /**
  * Get all the information about an account, including the balance. This does not get the list of

--- a/services/freeze.proto
+++ b/services/freeze.proto
@@ -26,7 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.freeze">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-import "duration.proto";
 import "timestamp.proto";
 import "basic_types.proto";
 import "freeze_type.proto";

--- a/services/response_header.proto
+++ b/services/response_header.proto
@@ -26,7 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-import "transaction_response.proto";
 import "query_header.proto";
 import "response_code.proto";
 

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -39,12 +39,12 @@ message BlockInfo {
   /**
    * The consensus time of the first transaction of the last block, this is the last completed immutable block.
    */
-  Timestamp first_cons_time_of_last_block = 2;
+  Timestamp first_cons_time_of_last_block = 3;
   /**
    * SHA384 48 byte hashes of the last 256 blocks in single byte array.
    * First 48 bytes is the oldest block.
    * Last 48 bytes is the newest block, which is the last fully completed immutable block.
    * If we are shortly after genesis and there are less than 256 blocks then this could contain less than 256 hashes.
    */
-  bytes block_hashes = 3;
+  bytes block_hashes = 2;
 }

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -39,12 +39,12 @@ message BlockInfo {
   /**
    * The consensus time of the first transaction of the last block, this is the last completed immutable block.
    */
-  Timestamp first_cons_time_of_last_block = 3;
+  Timestamp first_cons_time_of_last_block = 2;
   /**
    * SHA384 48 byte hashes of the last 256 blocks in single byte array.
    * First 48 bytes is the oldest block.
    * Last 48 bytes is the newest block, which is the last fully completed immutable block.
    * If we are shortly after genesis and there are less than 256 blocks then this could contain less than 256 hashes.
    */
-  bytes block_hashes = 2;
+  bytes block_hashes = 3;
 }

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -61,7 +61,7 @@ message Topic {
     /**
      * The topic's consensus expiration time in seconds since the epoch.
      */
-    int64 expiry = 3;
+    int64 expiration_seconds = 3;
     /**
      * The number of seconds for which the topic will be automatically renewed 
      * upon expiring (if it has a valid auto-renew account).

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -29,7 +29,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Consensus Service topic in the network Merkle tree. 
+ * Representation of a Hedera Consensus Service topic in the network Merkle tree.
  * 
  * As with all network entities, a topic has a unique entity number, which is usually given along 
  * with the network's shard and realm in the form of a shard.realm.number id.
@@ -51,9 +51,9 @@ option java_multiple_files = true;
  */
 message Topic {
     /**
-     * The topic's unique id number in the Merkle state.
+     * The topic's unique id in the Merkle state.
      */
-    TopicID id = 1;
+    TopicID topic_id = 7;
     /**
      * The number of messages sent to the topic.
      */
@@ -71,11 +71,11 @@ message Topic {
      * The id of the account (if any) that the network will attempt to charge for the
      * topic's auto-renewal upon expiration.
      */
-    AccountID auto_renew_account_id = 5;
+    AccountID auto_renew_account_id = 8;
     /**
      * Whether this topic is deleted.
      */
-    bool deleted = 6;
+    bool deleted = 1;
     /**
      * When a topic is created, its running hash is initialized to 48 bytes of binary zeros.
      * For each submitted message, the topic's running hash is then updated to the output
@@ -84,11 +84,11 @@ message Topic {
      * See the TransactionReceipt.proto documentation for an exact description of the
      * data included in the SHA-384 digest used for the update.
      */
-    bytes running_hash = 7;
+    bytes running_hash = 6;
     /**
      * An optional description of the topic with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 8;
+    string memo = 5;
     /**
      * If present, enforces access control for updating or deleting the topic.
      * A topic without an admin key is immutable.

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -61,7 +61,7 @@ message Topic {
     /**
      * The topic's consensus expiration time in seconds since the epoch.
      */
-    int64 expiration_seconds = 3;
+    int64 expiration_second = 3;
     /**
      * The number of seconds for which the topic will be automatically renewed 
      * upon expiring (if it has a valid auto-renew account).

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -53,7 +53,7 @@ message Topic {
     /**
      * The topic's unique id in the Merkle state.
      */
-    TopicID topic_id = 7;
+    TopicID topic_id = 1;
     /**
      * The number of messages sent to the topic.
      */
@@ -71,11 +71,11 @@ message Topic {
      * The id of the account (if any) that the network will attempt to charge for the
      * topic's auto-renewal upon expiration.
      */
-    AccountID auto_renew_account_id = 8;
+    AccountID auto_renew_account_id = 5;
     /**
      * Whether this topic is deleted.
      */
-    bool deleted = 1;
+    bool deleted = 6;
     /**
      * When a topic is created, its running hash is initialized to 48 bytes of binary zeros.
      * For each submitted message, the topic's running hash is then updated to the output
@@ -84,11 +84,11 @@ message Topic {
      * See the TransactionReceipt.proto documentation for an exact description of the
      * data included in the SHA-384 digest used for the update.
      */
-    bytes running_hash = 6;
+    bytes running_hash = 7;
     /**
      * An optional description of the topic with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 5;
+    string memo = 8;
     /**
      * If present, enforces access control for updating or deleting the topic.
      * A topic without an admin key is immutable.

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -48,8 +48,8 @@ message SlotKey {
 /**
  * The value of a contract storage slot. For the EVM, this is a single word.
  * 
- * But because we need to be able to iterate through all the storage slots for an 
- * expired contract when purging it from state, our slot values also include the words 
+ * Because we iterate through all the storage slots for an expired contract
+ * when purging it from state, our slot values also include the words
  * of the previous and next keys in this contract's storage "list". 
  */
 message SlotValue {

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -22,8 +22,6 @@ package proto;
  * ‍
  */
 
-import "state/common.proto";
-
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -23,7 +23,6 @@ package proto;
  */
 
 import "basic_types.proto";
-import "timestamp.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -42,7 +42,7 @@ message File {
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
-    int64 expiration_seconds = 2;
+    int64 expiration_second = 2;
     /**
      * All keys at the top level of a key list must sign to create, modify and delete the file.
      */

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -30,24 +30,24 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service file in the network Merkle tree.
+ * Representation of a Hedera Token Service file in the network Merkle tree.
  *
- * As with all network entities, a file has a unique entity number, which is usually given along
+ * As with all network entities, a file has a unique entity number, which is given along
  * with the network's shard and realm in the form of a shard.realm.number id.
  */
 message File {
     /**
      * The file's unique file identifier in the Merkle state.
      */
-    FileID file_id = 1;
+    FileID file_id = 5;
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
-    int64 expiration_time = 2;
+    int64 expiry = 2;
     /**
      * All keys at the top level of a key list must sign to create, modify and delete the file.
      */
-    KeyList keys = 3;
+    KeyList keys = 6;
     /**
      * The bytes that are the contents of the file
      */
@@ -55,9 +55,9 @@ message File {
     /**
      * The memo associated with the file (UTF-8 encoding max 100 bytes)
      */
-    string memo = 5;
+    string memo = 3;
     /**
      * Whether this file is deleted.
      */
-    bool deleted = 6;
+    bool deleted = 1;
 }

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -43,7 +43,7 @@ message File {
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
-    int64 expiry = 2;
+    int64 expiration_seconds = 2;
     /**
      * All keys at the top level of a key list must sign to create, modify and delete the file.
      */

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -39,7 +39,7 @@ message File {
     /**
      * The file's unique file identifier in the Merkle state.
      */
-    FileID file_id = 5;
+    FileID file_id = 1;
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
@@ -47,7 +47,7 @@ message File {
     /**
      * All keys at the top level of a key list must sign to create, modify and delete the file.
      */
-    KeyList keys = 6;
+    KeyList keys = 3;
     /**
      * The bytes that are the contents of the file
      */
@@ -55,9 +55,9 @@ message File {
     /**
      * The memo associated with the file (UTF-8 encoding max 100 bytes)
      */
-    string memo = 3;
+    string memo = 5;
     /**
      * Whether this file is deleted.
      */
-    bool deleted = 1;
+    bool deleted = 6;
 }

--- a/services/state/primitives.proto
+++ b/services/state/primitives.proto
@@ -24,8 +24,8 @@ package proto;
  * type instead.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java.primitive";
-// <<<pbj.java_package = "com.hedera.hapi.node.state.primitive">>> This comment is special code for setting PBJ Compiler java package
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.primitives">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -100,7 +100,7 @@ message Schedule {
      * The requested expiration time of the schedule as provided by the user.
      * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
-    Timestamp expiry_provided = 10;
+    int64 provided_expiration_seconds = 10;
 
     /**
      * The calculated expiration time of the schedule.  This is calculated based on the requested
@@ -109,7 +109,7 @@ message Schedule {
      * The schedule will be removed from global network state after the network reaches a consensus
      * time greater than or equal to this value.
      */
-    Timestamp calculated_expiry = 11;
+    int64 calculated_expiration_seconds = 11;
 
     /**
      * The consensus timestamp of the transaction that executed or deleted this schedule.

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -71,19 +71,19 @@ message Schedule {
     /**
      * This schedule's unique ID within the global network state.
      */
-    ScheduleID id = 5;
+    ScheduleID schedule_id = 5;
 
     /**
      * The schedule account for this schedule.  This is the account that submitted the original
      * ScheduleCreate transaction.
      */
-    AccountID scheduler_account = 6;
+    AccountID scheduler_account_id = 6;
 
     /**
      * The explicit payer account for the scheduled transaction.
      * This account is added to the accounts that must sign the schedule before it will execute.
      */
-    AccountID payer_account = 7;
+    AccountID payer_account_id = 7;
 
     /**
      * The admin key for this schedule.
@@ -100,7 +100,7 @@ message Schedule {
      * The requested expiration time of the schedule as provided by the user.
      * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
-    Timestamp expiration_time_provided = 10;
+    Timestamp expiry_provided = 10;
 
     /**
      * The calculated expiration time of the schedule.  This is calculated based on the requested
@@ -109,7 +109,7 @@ message Schedule {
      * The schedule will be removed from global network state after the network reaches a consensus
      * time greater than or equal to this value.
      */
-    Timestamp calculated_expiration_time = 11;
+    Timestamp calculated_expiry = 11;
 
     /**
      * The consensus timestamp of the transaction that executed or deleted this schedule.

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -99,7 +99,7 @@ message Schedule {
      * The requested expiration time of the schedule as provided by the user.
      * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
-    int64 provided_expiration_seconds = 10;
+    int64 provided_expiration_second = 10;
 
     /**
      * The calculated expiration time of the schedule.  This is calculated based on the requested
@@ -108,7 +108,7 @@ message Schedule {
      * The schedule will be removed from global network state after the network reaches a consensus
      * time greater than or equal to this value.
      */
-    int64 calculated_expiration_seconds = 11;
+    int64 calculated_expiration_second = 11;
 
     /**
      * The consensus timestamp of the transaction that executed or deleted this schedule.

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -38,18 +38,22 @@ option java_multiple_files = true;
  * with the network's shard and realm in the form of a shard.realm.number id.
  */
 message Schedule {
+    /**
+     * This schedule's unique ID within the global network state.
+     */
+    ScheduleID schedule_id = 1;
 
     /**
      * The schedule deleted flag
      * A schedule will either be executed or deleted, but never both.
      */
-    bool deleted = 1;
+    bool deleted = 2;
 
     /**
      * The schedule executed flag
      * A schedule will either be executed or deleted, but never both.
      */
-    bool executed = 2;
+    bool executed = 3;
 
     /**
      * The schedule flag to wait for expiration
@@ -61,17 +65,12 @@ message Schedule {
      * Note that a schedule is always removed from state when it expires, regardless of whether it
      * was executed or not.
      */
-    bool wait_for_expiry = 3;
+    bool wait_for_expiry = 4;
 
     /**
      * The memo associated with this schedule.
      */
-    string memo = 4;
-
-    /**
-     * This schedule's unique ID within the global network state.
-     */
-    ScheduleID schedule_id = 5;
+    string memo = 5;
 
     /**
      * The schedule account for this schedule.  This is the account that submitted the original
@@ -145,5 +144,5 @@ message ScheduleList {
   /**
    * a list of schedules, in no particular order.
    */
-  repeated Schedule schedules = 2;
+  repeated Schedule schedules = 1;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -40,42 +40,42 @@ message Account {
     /**
      * The unique entity id of the account.
      */
-    AccountID account_id = 25;
+    AccountID account_id = 1;
     /**
      * The alias to use for this account, if any.
      */
-    bytes alias = 23;
+    bytes alias = 22;
     /**
      * (Optional) The key to be used to sign transactions from the account, if any.
      * This key will not be set for hollow accounts until the account is finalized.
      * This key should be set on all the accounts, except for immutable accounts (0.0.800 and 0.0.801).
      */
-    Key key = 26;
+    Key key = 3;
     /**
      * The expiration time of the account, in seconds since the epoch.
      */
-    int64 expiration_seconds = 12;
+    int64 expiration_seconds = 4;
     /**
      * The balance of the account, in tiny-bars.
      */
-    int64 tinybar_balance = 13;
+    int64 tinybar_balance = 5;
     /**
      * An optional description of the account with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 22;
+    string memo = 6;
     /**
      * A boolean marking if the account has been deleted.
      */
-    bool deleted = 1;
+    bool deleted = 7;
     /**
      * The amount of hbars staked to the account.
      */
-    int64 staked_to_me = 14;
+    int64 staked_to_me = 8;
     /**
      * If this account stakes to another account, its value will be -1. It will
      * be set to the time when the account starts staking to a node.
      */
-    int64 stake_period_start = 15;
+    int64 stake_period_start = 9;
 
     /**
      * ID of the account or node to which this account is staking.
@@ -85,110 +85,110 @@ message Account {
              * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
              * removes this account's staked node ID.
          */
-        int64 staked_node_id = 16;
+        int64 staked_node_id = 10;
 
         /**
          * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
          * this field removes this account's staked account ID.
          */
-        AccountID staked_account_id = 30;
+        AccountID staked_account_id = 11;
     }
     /**
      * A boolean marking if the account declines rewards.
      */
-    bool decline_reward = 2;
+    bool decline_reward = 12;
     /**
      * A boolean marking if the account requires a receiver signature.
      */
-    bool receiver_sig_required = 3;
+    bool receiver_sig_required = 13;
     /**
      * The token ID of the head of the linked list from token relations map for the account.
      */
-    TokenID head_token_id = 27;
+    TokenID head_token_id = 14;
     /**
      * The NftID of the head of the linked list from unique tokens map for the account.
      */
-    NftID head_nft_id = 28;
+    NftID head_nft_id = 15;
     /**
       * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
-    int64 head_nft_serial_number = 17;
+    int64 head_nft_serial_number = 16;
     /**
      * The number of NFTs owned by the account.
      */
-    int64 number_owned_nfts = 18;
+    int64 number_owned_nfts = 17;
     /**
      * The maximum number of tokens that can be auto-associated with the account.
      */
-    int32 max_auto_associations = 6;
+    int32 max_auto_associations = 18;
     /**
      * The number of used auto-association slots.
      */
-    int32 used_auto_associations = 7;
+    int32 used_auto_associations = 19;
     /**
      * The number of tokens associated with the account. This number is used for
      * fee calculation during renewal of the account.
      */
-    int32 number_associations = 8;
+    int32 number_associations = 20;
     /**
      * A boolean marking if the account is a smart contract.
      */
-    bool smart_contract = 4;
+    bool smart_contract = 21;
     /**
      * The number of tokens with a positive balance associated with the account.
      * If the account has positive balance in a token, it can not be deleted.
      */
-    int32 number_positive_balances = 9;
+    int32 number_positive_balances = 22;
     /**
      * The nonce of the account, used for Ethereum interoperability.
      */
-    int64 ethereum_nonce = 19;
+    int64 ethereum_nonce = 23;
     /**
      * The amount of hbars staked to the account at the start of the last rewarded period.
      */
-    int64 stake_at_start_of_last_rewarded_period = 20;
+    int64 stake_at_start_of_last_rewarded_period = 24;
     /**
      * (Optional) The id of an auto-renew account, in the same shard and realm as the account, that
      * has signed a transaction allowing the network to use its balance to automatically extend the account's
      * expiration time when it passes.
      */
-    AccountID auto_renew_account_id = 29;
+    AccountID auto_renew_account_id = 25;
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
      * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 21;
+    int64 auto_renew_secs = 26;
     /**
      * If this account is a smart-contract, number of key-value pairs stored on the contract.
      * This is used to determine the storage rent for the contract.
      */
-    int32 contract_kv_pairs_number = 10;
+    int32 contract_kv_pairs_number = 27;
     /**
      * (Optional) List of crypto allowances approved by the account.
      * It contains account number for which the allowance is approved to and
      * the amount approved for that account.
      */
-    repeated AccountCryptoAllowance crypto_allowances = 31;
+    repeated AccountCryptoAllowance crypto_allowances = 28;
     /**
      * (Optional) List of non-fungible token allowances approved for all by the account.
      * It contains account number approved for spending all serial numbers for the given
      * NFT token number using approved_for_all flag.
      * Allowances for a specific serial number is stored in the NFT itself in state.
      */
-    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 32;
+    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 29;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
      * It contains account number for which the allowance is approved to and  the token number.
      * It also contains and the amount approved for that account.
      */
-    repeated AccountFungibleTokenAllowance token_allowances = 33;
+    repeated AccountFungibleTokenAllowance token_allowances = 30;
     /**
      * The number of tokens for which this account is treasury
      */
-    uint32 number_treasury_titles = 11;
+    uint32 number_treasury_titles = 31;
     /**
      * A flag indicating if the account is expired and pending removal.
      * Only the entity expiration system task toggles this flag when it reaches this account
@@ -197,12 +197,12 @@ message Account {
      * auto-renew account from being treated as expired in the interval between its expiration
      * and the time the system task actually auto-renews it.
      */
-    bool expired_and_pending_removal = 5;
+    bool expired_and_pending_removal = 32;
     /**
      * The first key in the doubly-linked list of this contract's storage mappings;
      * It will be null if if the account is not a contract or the contract has no storage mappings.
      */
-    bytes first_contract_storage_key = 24;
+    bytes first_contract_storage_key = 33;
 }
 
 /**
@@ -221,9 +221,9 @@ message AccountApprovalForAllAllowance {
  * This allows spender to spend the amount of tokens approved for the account.
  */
 message AccountFungibleTokenAllowance {
-    TokenID token_id = 2;
-    AccountID spender_id = 3;
-    int64 amount = 1;
+    TokenID token_id = 1;
+    AccountID spender_id = 2;
+    int64 amount = 3;
 }
 
 /**
@@ -231,6 +231,6 @@ message AccountFungibleTokenAllowance {
  * This allows spender to spend the amount of hbars approved for the account.
  */
 message AccountCryptoAllowance {
-    AccountID spender_id = 2;
-    int64 amount = 1;
+    AccountID spender_id = 1;
+    int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -44,7 +44,7 @@ message Account {
     /**
      * The alias to use for this account, if any.
      */
-    bytes alias = 22;
+    bytes alias = 2;
     /**
      * (Optional) The key to be used to sign transactions from the account, if any.
      * This key will not be set for hollow accounts until the account is finalized.
@@ -82,16 +82,16 @@ message Account {
      */
     oneof staked_id {
         /**
-             * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
-             * removes this account's staked node ID.
-         */
-        int64 staked_node_id = 10;
-
-        /**
          * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
          * this field removes this account's staked account ID.
          */
-        AccountID staked_account_id = 11;
+        AccountID staked_account_id = 10;
+
+        /**
+             * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+             * removes this account's staked node ID.
+         */
+        int64 staked_node_id = 11;
     }
     /**
      * A boolean marking if the account declines rewards.

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -54,7 +54,7 @@ message Account {
     /**
      * The expiration time of the account, in seconds since the epoch.
      */
-    int64 expiry = 12;
+    int64 expiration_seconds = 12;
     /**
      * The balance of the account, in tiny-bars.
      */

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -54,7 +54,7 @@ message Account {
     /**
      * The expiration time of the account, in seconds since the epoch.
      */
-    int64 expiration_seconds = 4;
+    int64 expiration_second = 4;
     /**
      * The balance of the account, in tiny-bars.
      */
@@ -156,10 +156,10 @@ message Account {
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
-     * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * If this is not provided in an allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 26;
+    int64 auto_renew_seconds = 26;
     /**
      * If this account is a smart-contract, number of key-value pairs stored on the contract.
      * This is used to determine the storage rent for the contract.

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -30,167 +30,165 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service account entity in the network Merkle tree.
+ * Representation of a Hedera Token Service account entity in the network Merkle tree.
  *
- * As with all network entities, account has an unique entity number represented as shard.realm.X.
+ * As with all network entities, account has a unique entity number represented as shard.realm.X.
  * X can be an alias public key or an EVM address or a number.
- *
  */
 
 message Account {
     /**
      * The unique entity id of the account.
      */
-    AccountID account_id = 1;
+    AccountID account_id = 25;
     /**
      * The alias to use for this account, if any.
      */
-    bytes alias = 2;
+    bytes alias = 23;
     /**
      * (Optional) The key to be used to sign transactions from the account, if any.
      * This key will not be set for hollow accounts until the account is finalized.
      * This key should be set on all the accounts, except for immutable accounts (0.0.800 and 0.0.801).
      */
-    Key key = 3;
+    Key key = 26;
     /**
      * The expiration time of the account, in seconds since the epoch.
      */
-    int64 expiry = 4;
+    int64 expiry = 12;
     /**
      * The balance of the account, in tiny-bars.
      */
-    int64 tinybar_balance = 5;
+    int64 tinybar_balance = 13;
     /**
      * An optional description of the account with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 6;
+    string memo = 22;
     /**
      * A boolean marking if the account has been deleted.
      */
-    bool deleted = 7;
+    bool deleted = 1;
     /**
      * The amount of hbars staked to the account.
      */
-    int64 staked_to_me = 8;
+    int64 staked_to_me = 14;
     /**
      * If this account stakes to another account, its value will be -1. It will
      * be set to the time when the account starts staking to a node.
      */
-    int64 stake_period_start = 9;
+    int64 stake_period_start = 15;
 
     /**
      * ID of the account or node to which this account is staking.
      */
     oneof staked_id {
+        /**
+             * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+             * removes this account's staked node ID.
+         */
+        int64 staked_node_id = 16;
 
         /**
          * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
          * this field removes this account's staked account ID.
          */
-        AccountID staked_account_id = 10;
-
-    /**
-         * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
-         * removes this account's staked node ID.
-     */
-        int64 staked_node_id = 11;
+        AccountID staked_account_id = 30;
     }
     /**
      * A boolean marking if the account declines rewards.
      */
-    bool decline_reward = 12;
+    bool decline_reward = 2;
     /**
      * A boolean marking if the account requires a receiver signature.
      */
-    bool receiver_sig_required = 13;
+    bool receiver_sig_required = 3;
     /**
      * The token ID of the head of the linked list from token relations map for the account.
      */
-    TokenID head_token_id = 14;
+    TokenID head_token_id = 27;
     /**
      * The NftID of the head of the linked list from unique tokens map for the account.
      */
-    NftID head_nft_id = 15;
+    NftID head_nft_id = 28;
     /**
       * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
-    int64 head_nft_serial_number = 16;
+    int64 head_nft_serial_number = 17;
     /**
      * The number of NFTs owned by the account.
      */
-    int64 number_owned_nfts = 17;
+    int64 number_owned_nfts = 18;
     /**
      * The maximum number of tokens that can be auto-associated with the account.
      */
-    int32 max_auto_associations = 18;
+    int32 max_auto_associations = 6;
     /**
      * The number of used auto-association slots.
      */
-    int32 used_auto_associations = 19;
+    int32 used_auto_associations = 7;
     /**
      * The number of tokens associated with the account. This number is used for
      * fee calculation during renewal of the account.
      */
-    int32 number_associations = 20;
+    int32 number_associations = 8;
     /**
      * A boolean marking if the account is a smart contract.
      */
-    bool smart_contract = 21;
+    bool smart_contract = 4;
     /**
      * The number of tokens with a positive balance associated with the account.
      * If the account has positive balance in a token, it can not be deleted.
      */
-    int32 number_positive_balances = 22;
+    int32 number_positive_balances = 9;
     /**
      * The nonce of the account, used for Ethereum interoperability.
      */
-    int64 ethereum_nonce = 23;
+    int64 ethereum_nonce = 19;
     /**
      * The amount of hbars staked to the account at the start of the last rewarded period.
      */
-    int64 stake_at_start_of_last_rewarded_period = 24;
+    int64 stake_at_start_of_last_rewarded_period = 20;
     /**
      * (Optional) The id of an auto-renew account, in the same shard and realm as the account, that
      * has signed a transaction allowing the network to use its balance to automatically extend the account's
      * expiration time when it passes.
      */
-    AccountID auto_renew_account_id = 25;
+    AccountID auto_renew_account_id = 29;
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
      * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 26;
+    int64 auto_renew_secs = 21;
     /**
      * If this account is a smart-contract, number of key-value pairs stored on the contract.
      * This is used to determine the storage rent for the contract.
      */
-    int32 contract_kv_pairs_number = 27;
+    int32 contract_kv_pairs_number = 10;
     /**
      * (Optional) List of crypto allowances approved by the account.
      * It contains account number for which the allowance is approved to and
      * the amount approved for that account.
      */
-    repeated AccountCryptoAllowance crypto_allowances = 28;
+    repeated AccountCryptoAllowance crypto_allowances = 31;
     /**
      * (Optional) List of non-fungible token allowances approved for all by the account.
      * It contains account number approved for spending all serial numbers for the given
      * NFT token number using approved_for_all flag.
      * Allowances for a specific serial number is stored in the NFT itself in state.
      */
-    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 29;
+    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 32;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
      * It contains account number for which the allowance is approved to and  the token number.
      * It also contains and the amount approved for that account.
      */
-    repeated AccountFungibleTokenAllowance token_allowances = 30;
+    repeated AccountFungibleTokenAllowance token_allowances = 33;
     /**
      * The number of tokens for which this account is treasury
      */
-    uint32 number_treasury_titles = 31;
+    uint32 number_treasury_titles = 11;
     /**
      * A flag indicating if the account is expired and pending removal.
      * Only the entity expiration system task toggles this flag when it reaches this account
@@ -199,12 +197,12 @@ message Account {
      * auto-renew account from being treated as expired in the interval between its expiration
      * and the time the system task actually auto-renews it.
      */
-    bool expired_and_pending_removal = 32;
+    bool expired_and_pending_removal = 5;
     /**
      * The first key in the doubly-linked list of this contract's storage mappings;
      * It will be null if if the account is not a contract or the contract has no storage mappings.
      */
-    bytes first_contract_storage_key = 33;
+    bytes first_contract_storage_key = 24;
 }
 
 /**
@@ -223,9 +221,9 @@ message AccountApprovalForAllAllowance {
  * This allows spender to spend the amount of tokens approved for the account.
  */
 message AccountFungibleTokenAllowance {
-    TokenID token_id = 1;
-    AccountID spender_id = 2;
-    int64 amount = 3;
+    TokenID token_id = 2;
+    AccountID spender_id = 3;
+    int64 amount = 1;
 }
 
 /**
@@ -233,6 +231,6 @@ message AccountFungibleTokenAllowance {
  * This allows spender to spend the amount of hbars approved for the account.
  */
 message AccountCryptoAllowance {
-    AccountID spender_id = 1;
-    int64 amount = 2;
+    AccountID spender_id = 2;
+    int64 amount = 1;
 }

--- a/services/state/token/network_staking_rewards.proto
+++ b/services/state/token/network_staking_rewards.proto
@@ -27,12 +27,12 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service staking reward entity in the network Merkle tree.
- * This consist of all the information needed to calculate the staking rewards for all nodes in the network. It is
+ * Representation of a Hedera Token Service staking reward entity in the network Merkle tree.
+ * This consists of all the information needed to calculate the staking rewards for all nodes in the network. It is
  * calculated at the beginning of each staking period for all nodes and is needed to have same values
  * for reconnect.
  *
- * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
  */
 message NetworkStakingRewards {
 

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -37,7 +37,7 @@ message Nft {
     /**
      * The id of this NFT.
      */
-    NftID id = 2;
+    NftID nft_id = 2;
 
     /**
      * The account or contract id that owns this NFT.

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -30,38 +30,38 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service NFT in the network Merkle tree.
+ * Representation of a Hedera Token Service NFT in the network Merkle tree.
  */
 message Nft {
 
     /**
      * The id of this NFT.
      */
-    NftID id = 1;
+    NftID id = 2;
 
     /**
      * The account or contract id that owns this NFT.
      *
      * If this number is zero in state, the NFT is owned by its token type's current treasury.
      */
-    AccountID owner_id = 2;
+    AccountID owner_id = 3;
 
     /**
      * The account or contract id approved to spend this NFT.
      *
      * If this number is zero, there is no approved spender.
      */
-    AccountID spender_id = 3;
+    AccountID spender_id = 4;
 
     /**
      * The consensus time of the TokenMint that created this NFT.
      */
-    Timestamp mint_time = 4;
+    Timestamp mint_time = 5;
 
     /**
      * The metadata of this NFT, up to 100 bytes; usually the UTF-8 encoding of a URI.
      */
-    bytes metadata = 5;
+    bytes metadata = 1;
 
     /**
      * If the owner of this NFT is not its token treasury, the id of the previous NFT 

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -37,31 +37,31 @@ message Nft {
     /**
      * The id of this NFT.
      */
-    NftID nft_id = 2;
+    NftID nft_id = 1;
 
     /**
      * The account or contract id that owns this NFT.
      *
      * If this number is zero in state, the NFT is owned by its token type's current treasury.
      */
-    AccountID owner_id = 3;
+    AccountID owner_id = 2;
 
     /**
      * The account or contract id approved to spend this NFT.
      *
      * If this number is zero, there is no approved spender.
      */
-    AccountID spender_id = 4;
+    AccountID spender_id = 3;
 
     /**
      * The consensus time of the TokenMint that created this NFT.
      */
-    Timestamp mint_time = 5;
+    Timestamp mint_time = 4;
 
     /**
      * The metadata of this NFT, up to 100 bytes; usually the UTF-8 encoding of a URI.
      */
-    bytes metadata = 1;
+    bytes metadata = 5;
 
     /**
      * If the owner of this NFT is not its token treasury, the id of the previous NFT 

--- a/services/state/token/staking_node_info.proto
+++ b/services/state/token/staking_node_info.proto
@@ -30,9 +30,9 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service staking info entity in the network Merkle tree.
+ * Representation of a Hedera Token Service staking info entity in the network Merkle tree.
  *
- * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
  */
 message StakingNodeInfo {
     /**
@@ -79,7 +79,7 @@ message StakingNodeInfo {
      * is the reward up to and including the last full period that finished before the present. Second element is
      * the reward up to and including the period before that
      */
-    repeated int64 reward_sum_history = 9;
+    repeated int64 reward_sum_history = 10;
     /**
      * The consensus weight of this node in the network. This is computed based on the stake of this node
      * at midnight UTC of the current day. If the stake of this node is less than minStake, then the weight is 0.
@@ -87,5 +87,5 @@ message StakingNodeInfo {
      * If the stake of this node A is greater than minStake, then the weight of this node A is calculated as:
      * (node A stake * 500/ total stake of all nodes)
      */
-    int32 weight = 10;
+    int32 weight = 9;
 }

--- a/services/state/token/staking_node_info.proto
+++ b/services/state/token/staking_node_info.proto
@@ -79,7 +79,7 @@ message StakingNodeInfo {
      * is the reward up to and including the last full period that finished before the present. Second element is
      * the reward up to and including the period before that
      */
-    repeated int64 reward_sum_history = 10;
+    repeated int64 reward_sum_history = 9;
     /**
      * The consensus weight of this node in the network. This is computed based on the stake of this node
      * at midnight UTC of the current day. If the stake of this node is less than minStake, then the weight is 0.
@@ -87,5 +87,5 @@ message StakingNodeInfo {
      * If the stake of this node A is greater than minStake, then the weight of this node A is calculated as:
      * (node A stake * 500/ total stake of all nodes)
      */
-    int32 weight = 9;
+    int32 weight = 10;
 }

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -132,11 +132,11 @@ message Token {
      * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 19;
+    int64 auto_renew_seconds = 19;
     /**
      * The expiration time of the token, in seconds since the epoch.
      */
-    int64 expiration_seconds = 20;
+    int64 expiration_second = 20;
     /**
      * An optional description of the token with UTF-8 encoding up to 100 bytes.
      */

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -30,7 +30,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service token entity in the network Merkle tree.
+ * Representation of a Hedera Token Service token entity in the network Merkle tree.
  *
  * As with all network entities, a token has a unique entity number, which is usually given along
  * with the network's shard and realm in the form of a shard.realm.number id.
@@ -40,123 +40,123 @@ message Token {
     /**
      * The unique entity id of this token.
      */
-    TokenID token_id = 1;
+    TokenID token_id = 14;
     /**
-     * The human-readable name of this token and its not necessarily unique. Maximum length allowed is 100 bytes.
+     * The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
      */
-    string name = 2;
+    string name = 11;
     /**
      * The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
      */
-    string symbol = 3;
+    string symbol = 12;
     /**
      * The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
      * tokens can be at most a few billions or millions, respectively. For example, it could match
      * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
      * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
      */
-    int32 decimals = 4;
+    int32 decimals = 5;
     /**
      * The total supply of this token.
      */
-    int64 total_supply = 5;
+    int64 total_supply = 6;
     /**
      * The treasury account id of this token. This account receives the initial supply of
-     * tokens as-well as the tokens from the Token Mint operation once executed. The balance
+     * tokens as well as the tokens from the Token Mint operation once executed. The balance
      * of the treasury account is decreased when the Token Burn operation is executed.
      */
-    AccountID treasury_account_id = 6;
+    AccountID treasury_account_id = 15;
     /**
      * (Optional) The admin key of this token. If this key is set, the token is mutable.
      * A mutable token can be modified.
      * If this key is not set on token creation, it cannot be modified.
      */
-    Key admin_key = 7;
+    Key admin_key = 16;
     /**
      * (Optional) The kyc key of this token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key kyc_key = 8;
+    Key kyc_key = 17;
     /**
      * (Optional) The freeze key of this token. This key is needed for freezing the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key freeze_key = 9;
+    Key freeze_key = 18;
     /**
      * (Optional) The wipe key of this token. This key is needed for wiping the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key wipe_key = 10;
+    Key wipe_key = 19;
     /**
      * (Optional) The supply key of this token. This key is needed for minting or burning token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key supply_key = 11;
+    Key supply_key = 20;
     /**
      * (Optional) The fee schedule key of this token. This key should be set, in order to make any
      * changes to the custom fee schedule.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key fee_schedule_key = 12;
+    Key fee_schedule_key = 21;
     /**
      * (Optional) The pause key of this token. This key is needed for pausing the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key pause_key = 13;
+    Key pause_key = 22;
     /**
      * The last used serial number of this token.
      */
-    int64 last_used_serial_number = 14;
+    int64 last_used_serial_number = 7;
     /**
      * The flag indicating if this token is deleted.
      */
-    bool deleted = 15;
+    bool deleted = 1;
     /**
      * The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
      * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
      */
-    TokenType token_type = 16;
+    TokenType token_type = 23;
     /**
      * The supply type of this token.A token can have either INFINITE or FINITE supply type.
      * If it has been omitted during token creation, INFINITE type is used.
      */
-    TokenSupplyType supply_type = 17;
+    TokenSupplyType supply_type = 24;
     /**
      * The id of the account (if any) that the network will attempt to charge for the
      * token's auto-renewal upon expiration.
      */
-    AccountID auto_renew_account_id = 18;
+    AccountID auto_renew_account_id = 25;
     /**
      * The number of seconds the network should automatically extend the token's expiration by, if the
      * token has a valid auto-renew account, and is not deleted upon expiration.
      * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 19;
+    int64 auto_renew_secs = 8;
     /**
      * The expiration time of the token, in seconds since the epoch.
      */
-    int64 expiry = 20;
+    int64 expiry = 9;
     /**
      * An optional description of the token with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 21;
+    string memo = 13;
     /**
      * The maximum supply of this token.
      */
-    int64 max_supply = 22;
+    int64 max_supply = 10;
     /**
      * The flag indicating if this token is paused.
      */
-    bool paused = 23;
+    bool paused = 2;
     /**
      * The flag indicating if this token has accounts associated to it that are frozen by default.
      */
-    bool accounts_frozen_by_default = 24;
+    bool accounts_frozen_by_default = 3;
     /**
-      * The flag indicating if this token has accounts associated to it that are KYC granted by default.
+      * The flag indicating if this token has accounts associated with it that are KYC granted by default.
      */
-    bool accounts_kyc_granted_by_default = 25;
+    bool accounts_kyc_granted_by_default = 4;
     /**
      * (Optional) The custom fees of this token.
      */

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -136,7 +136,7 @@ message Token {
     /**
      * The expiration time of the token, in seconds since the epoch.
      */
-    int64 expiry = 9;
+    int64 expiration_seconds = 9;
     /**
      * An optional description of the token with UTF-8 encoding up to 100 bytes.
      */

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -40,123 +40,123 @@ message Token {
     /**
      * The unique entity id of this token.
      */
-    TokenID token_id = 14;
+    TokenID token_id = 1;
     /**
      * The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
      */
-    string name = 11;
+    string name = 2;
     /**
      * The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
      */
-    string symbol = 12;
+    string symbol = 3;
     /**
      * The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
      * tokens can be at most a few billions or millions, respectively. For example, it could match
      * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
      * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
      */
-    int32 decimals = 5;
+    int32 decimals = 4;
     /**
      * The total supply of this token.
      */
-    int64 total_supply = 6;
+    int64 total_supply = 5;
     /**
      * The treasury account id of this token. This account receives the initial supply of
      * tokens as well as the tokens from the Token Mint operation once executed. The balance
      * of the treasury account is decreased when the Token Burn operation is executed.
      */
-    AccountID treasury_account_id = 15;
+    AccountID treasury_account_id = 6;
     /**
      * (Optional) The admin key of this token. If this key is set, the token is mutable.
      * A mutable token can be modified.
      * If this key is not set on token creation, it cannot be modified.
      */
-    Key admin_key = 16;
+    Key admin_key = 7;
     /**
      * (Optional) The kyc key of this token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key kyc_key = 17;
+    Key kyc_key = 8;
     /**
      * (Optional) The freeze key of this token. This key is needed for freezing the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key freeze_key = 18;
+    Key freeze_key = 9;
     /**
      * (Optional) The wipe key of this token. This key is needed for wiping the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key wipe_key = 19;
+    Key wipe_key = 10;
     /**
      * (Optional) The supply key of this token. This key is needed for minting or burning token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key supply_key = 20;
+    Key supply_key = 11;
     /**
      * (Optional) The fee schedule key of this token. This key should be set, in order to make any
      * changes to the custom fee schedule.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key fee_schedule_key = 21;
+    Key fee_schedule_key = 12;
     /**
      * (Optional) The pause key of this token. This key is needed for pausing the token.
      * If this key is not set on token creation, it can only be set if the token has admin key set.
      */
-    Key pause_key = 22;
+    Key pause_key = 13;
     /**
      * The last used serial number of this token.
      */
-    int64 last_used_serial_number = 7;
+    int64 last_used_serial_number = 14;
     /**
      * The flag indicating if this token is deleted.
      */
-    bool deleted = 1;
+    bool deleted = 15;
     /**
      * The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
      * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
      */
-    TokenType token_type = 23;
+    TokenType token_type = 16;
     /**
      * The supply type of this token.A token can have either INFINITE or FINITE supply type.
      * If it has been omitted during token creation, INFINITE type is used.
      */
-    TokenSupplyType supply_type = 24;
+    TokenSupplyType supply_type = 17;
     /**
      * The id of the account (if any) that the network will attempt to charge for the
      * token's auto-renewal upon expiration.
      */
-    AccountID auto_renew_account_id = 25;
+    AccountID auto_renew_account_id = 18;
     /**
      * The number of seconds the network should automatically extend the token's expiration by, if the
      * token has a valid auto-renew account, and is not deleted upon expiration.
      * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 8;
+    int64 auto_renew_secs = 19;
     /**
      * The expiration time of the token, in seconds since the epoch.
      */
-    int64 expiration_seconds = 9;
+    int64 expiration_seconds = 20;
     /**
      * An optional description of the token with UTF-8 encoding up to 100 bytes.
      */
-    string memo = 13;
+    string memo = 21;
     /**
      * The maximum supply of this token.
      */
-    int64 max_supply = 10;
+    int64 max_supply = 22;
     /**
      * The flag indicating if this token is paused.
      */
-    bool paused = 2;
+    bool paused = 23;
     /**
      * The flag indicating if this token has accounts associated to it that are frozen by default.
      */
-    bool accounts_frozen_by_default = 3;
+    bool accounts_frozen_by_default = 24;
     /**
       * The flag indicating if this token has accounts associated with it that are KYC granted by default.
      */
-    bool accounts_kyc_granted_by_default = 4;
+    bool accounts_kyc_granted_by_default = 25;
     /**
      * (Optional) The custom fees of this token.
      */

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -28,7 +28,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 /**
- * First-draft representation of a Hedera Token Service token relationship entity in the network Merkle tree.
+ * Representation of a Hedera Token Service token relationship entity in the network Merkle tree.
  *
  * As with all network entities, a token relationship has a unique entity number pair, which is represented
  * with the account and the token involved in the relationship.
@@ -37,31 +37,31 @@ message TokenRelation {
     /**
      * The token involved in this relation.It takes only positive
      */
-    TokenID token_id = 1;
+    TokenID token_id = 6;
     /**
      * The account involved in this association.
      */
-    AccountID account_id = 2;
+    AccountID account_id = 7;
     /**
      * The balance of the token relationship.
      */
-    int64 balance = 3;
+    int64 balance = 5;
     /**
      * The flags specifying the token relationship is frozen or not.
      */
-    bool frozen = 4;
+    bool frozen = 1;
     /**
      * The flag indicating if the token relationship has been granted KYC.
      */
-    bool kyc_granted = 5;
+    bool kyc_granted = 2;
     /**
      * The flag indicating if the token relationship was deleted.
      */
-    bool deleted = 6;
+    bool deleted = 3;
     /**
      * The flag indicating if the token relationship was created using automatic association.
      */
-    bool automatic_association = 7;
+    bool automatic_association = 4;
     /**
      * The previous token id of account's association linked list
      */

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -37,31 +37,31 @@ message TokenRelation {
     /**
      * The token involved in this relation.It takes only positive
      */
-    TokenID token_id = 6;
+    TokenID token_id = 1;
     /**
      * The account involved in this association.
      */
-    AccountID account_id = 7;
+    AccountID account_id = 2;
     /**
      * The balance of the token relationship.
      */
-    int64 balance = 5;
+    int64 balance = 3;
     /**
      * The flags specifying the token relationship is frozen or not.
      */
-    bool frozen = 1;
+    bool frozen = 4;
     /**
      * The flag indicating if the token relationship has been granted KYC.
      */
-    bool kyc_granted = 2;
+    bool kyc_granted = 5;
     /**
      * The flag indicating if the token relationship was deleted.
      */
-    bool deleted = 3;
+    bool deleted = 6;
     /**
      * The flag indicating if the token relationship was created using automatic association.
      */
-    bool automatic_association = 4;
+    bool automatic_association = 7;
     /**
      * The previous token id of account's association linked list
      */

--- a/services/transaction.proto
+++ b/services/transaction.proto
@@ -26,8 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-
-import "duration.proto";
 import "basic_types.proto";
 import "transaction_body.proto";
 


### PR DESCRIPTION
**Description**:
Clean up files in services/state for consistency in naming
-Rename expiration_time -> expiration_second in several fields where it occurs
-Rename num -> number in several places
-Rename auto_renew_secs -> auto_renew_seconds
-Rename some id fields. All id fields are now of the form [message name]_id
-Remove unused imports
-Edits to comments

**Related issue(s)**:

Fixes #7684 in hedera-services

**Notes for reviewer**:
DO NOT MERGE until after [PR # 7986](https://github.com/hashgraph/hedera-services/pull/7986) in hedera-services is merged
