### PR TITLE
Add Protobuf messages for primitive values and a list of Schedules.

### DIFF
--- a/services/state/primitives.proto
+++ b/services/state/primitives.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package proto;
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This proto file contains primitive value messages.
+ * These are intended only for situations where the entire value to be stored in state is a single
+ * primitive.  These should never be used as components of another message; use the protobuf
+ * type instead.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java.primitive";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.primitive">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single 64-bit number with no particular meaning.
+ */
+message ProtoLong {
+    int64 value = 1;
+}
+
+/**
+ * A single 32-bit number with no particular meaning.
+ */
+message ProtoInteger {
+    int32 value = 1;
+}
+
+/**
+ * A single boolean with no particular meaning.
+ */
+message ProtoBoolean {
+    bool value = 1;
+}
+
+/**
+ * A single string with no particular meaning.
+ */
+message ProtoString {
+    string value = 1;
+}
+
+/**
+ * A single byte array with no particular meaning.
+ */
+message ProtoBytes {
+    bytes value = 1;
+}
+

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -135,3 +135,15 @@ message Schedule {
      */
     repeated Key signatories = 15;
 }
+
+/**
+ * A message for storing a list of schedules in state.
+ * This is used to store lists of schedules that expire at a particular time or that have the same
+ * simplified hash code.
+ */
+message ScheduleList {
+  /**
+   * a list of schedules, in no particular order.
+   */
+  repeated Schedule schedules = 2;
+}


### PR DESCRIPTION
 * Added primitive.proto which includes ProtoLong, ProtoInteger, ProtoBoolen, ProtoString, and ProtoBytes.
 * Added ScheduleList message to schedule.proto

This is half of the [related issue](https://github.com/hashgraph/hedera-services/issues/7779).  The other half (code changes to use the new protobuf messages and remove Codec implementations) will follow.