### PR TITLE
Add `BlockInfo#first_cons_time_of_current_block`

### DIFF
--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -59,4 +59,9 @@ message BlockInfo {
    * should happen during the first transaction handled by the node.
    */
   bool migration_records_streamed = 5;
+  /**
+   * The consensus time of the first transaction in the current block; necessary for reconnecting nodes to detect
+   * when the current block is finished.
+   */
+  Timestamp first_cons_time_of_current_block = 6;
 }


### PR DESCRIPTION
**Description**:
 - We must keep the provisional consensus time of the current block in state so reconnecting nodes can deterministically decide when to close the current block and begin the next one.
