### PR TITLE
Protobuf changes for implementation of metadata hips 646, 657 and 765

### DIFF
--- a/services/token_create.proto
+++ b/services/token_create.proto
@@ -198,4 +198,15 @@ message TokenCreateTransactionBody {
      * If Empty the token pause status defaults to PauseNotApplicable, otherwise Unpaused.
      */
     Key pause_key = 22;
+
+    /**
+   * Metadata of the created token definition.
+   */
+    bytes metadata = 23;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 24;
 }

--- a/services/token_update.proto
+++ b/services/token_update.proto
@@ -142,4 +142,15 @@ message TokenUpdateTransactionBody {
      * transaction will resolve to TOKEN_HAS_NO_PAUSE_KEY
      */
     Key pause_key = 15;
+
+    /**
+     * Metadata of the created token definition
+     */
+    google.protobuf.BytesValue metadata = 16;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 17;
 }

--- a/services/token_update_nft.proto
+++ b/services/token_update_nft.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2024 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * At consensus, updates an already created Non Fungible Token to the given values.
+ * 
+ * If no value is given for a field, that field is left unchanged. For an immutable tokens (that is,
+ * a token without an admin key), only the expiry may be updated. Setting any other field in that
+ * case will cause the transaction status to resolve to TOKEN_IS_IMMUTABLE.
+ *
+ */
+message TokenUpdateNftTransactionBody {
+    /**
+     * The NftID of the NFT
+     */
+    NftID nft_id = 1;
+
+    /**
+     * The new metadata of the NFT
+     */
+    google.protobuf.BytesValue metadata = 2;
+}


### PR DESCRIPTION
**Description**:

This PR modifies the token_create, token_update 
and creates a new token_nft_update.proto in order to support 
the 3 metadata related HIPs - [646, 657 and 765]

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/10931

**Fixes**:
https://github.com/hashgraph/hedera-services/issues/10932

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
