### PR TITLE
315 Added fully-qualified name for a type of `ContractFunctionResult.signer_nonce`

### DIFF
--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -174,7 +174,7 @@ message ContractFunctionResult {
      * If not null this field specifies what the value of the signer account nonce is post transaction execution. 
      * For transactions that don't update the signer nonce, this field should be null.
      */
-    Int64Value signer_nonce = 15;
+    google.protobuf.Int64Value signer_nonce = 15;
 }
 
 /**


### PR DESCRIPTION
 Added fully-qualified name for a type of `ContractFunctionResult.signer_nonce`

Fixes #315 

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
