### PR TITLE
Use contract id in slot key

### DIFF
--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -59,4 +59,9 @@ message BlockInfo {
    * should happen during the first transaction handled by the node.
    */
   bool migration_records_streamed = 5;
+  /**
+   * The consensus time of the first transaction in the current block; necessary for reconnecting nodes to detect
+   * when the current block is finished.
+   */
+  Timestamp first_cons_time_of_current_block = 6;
 }

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -37,7 +37,7 @@ message SlotKey {
     /**
      * The number of the contract whose storage this slot belongs to.
      */
-    ContractID contract_number = 1;
+    ContractID contractID = 1;
 
     /**
      * The EVM key of this slot, when left-padded with zeros to form a 256-bit word.

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -26,6 +26,8 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
+import "basic_types.proto";
+
 /**
  * The key of a storage slot. A slot is scoped to a specific contract number.
  * 
@@ -35,7 +37,7 @@ message SlotKey {
     /**
      * The number of the contract whose storage this slot belongs to.
      */
-    int64 contract_number = 1;
+    ContractID contract_number = 1;
 
     /**
      * The EVM key of this slot, when left-padded with zeros to form a 256-bit word.


### PR DESCRIPTION
**Description**:
Change long to ContractID in the SlotKey message. This is necessary to support sharding in the future.

**Related issue(s)**:
This PR + https://github.com/hashgraph/hedera-services/pull/10958 together fix https://github.com/hashgraph/hedera-services/issues/10746
