### PR TITLE
feat: Add `Comparable` to State Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ must be paid in ℏ from a cryptocurrency account. The payer authorizes a
 fee by signing an appropriate transaction with a sufficient subset of the 
 Ed25519 key(s) associated to their account.
 
+## Overview of state
+State directory and its subdirectories contain the protobuf files that define the state of the network.
+The state is divided into the following subdirectories, based on the service modules:
+1. [Token](services/state/token) - The state of the Token service.
+2. [Consensus](services/state/consensus) - The state of the Consensus service.
+
+The state directory and its subdirectories  are in preview and are subject to change.
+
 # For Developers
 
 ## Branching

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1165,6 +1165,11 @@ enum HederaFunctionality {
      * Generates a pseudorandom number.
      */
     UtilPrng = 86;
+
+    /**
+     * Get a record for a transaction.
+     */
+    TransactionGetFastRecord = 87;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -114,6 +114,21 @@ message AccountID {
 }
 
 /**
+ * Identifier for a unique token (or "NFT"), used by both contract and token services.
+ */
+message NftID {
+    /**
+     * The (non-fungible) token of which this NFT is an instance
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The serial number of this NFT within its token type
+     */
+    int64 serial_number = 2;
+}
+
+/**
  * The ID for a file 
  */
 message FileID {

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -118,9 +118,10 @@ message AccountID {
  */
 message NftID {
     /**
-     * The (non-fungible) token of which this NFT is an instance
+     * The (non-fungible) token of which this NFT is an instance; uppercase for "ID"
+     * for backward compatibility with original definition of this field.
      */
-    TokenID token_id = 1;
+    TokenID token_ID = 1;
 
     /**
      * The serial number of this NFT within its token type

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "timestamp.proto";
@@ -43,6 +43,7 @@ option java_multiple_files = true;
  * could potentially run in other realms in  parallel. So realms allow Solidity to be parallelized
  * somewhat, even though the  language itself assumes everything is serial.
  */
+// <<<pbj.comparable = "shardNum" >>>
 message ShardID {
     /**
      * the shard number (nonnegative)
@@ -54,6 +55,7 @@ message ShardID {
  * The ID for a realm. Within a given shard, every realm has a unique ID. Each account, file, and
  * contract instance belongs to exactly one realm.
  */
+// <<<pbj.comparable = "shardNum, realmNum" >>>
 message RealmID {
     /**
      * The shard number (nonnegative)
@@ -67,8 +69,31 @@ message RealmID {
 }
 
 /**
- * The ID for an a cryptocurrency account 
+ * Unique identifier for a token
+ * Note: This must be defined before any message that uses it, due to current limitations in the compiler.
  */
+// <<<pbj.comparable = "shardNum, realmNum, tokenNum" >>>
+message TokenID {
+    /**
+     * A nonnegative shard number
+     */
+    int64 shardNum = 1;
+
+    /**
+     * A nonnegative realm number
+     */
+    int64 realmNum = 2;
+
+    /**
+     * A nonnegative token number
+     */
+    int64 tokenNum = 3;
+}
+
+/**
+ * The ID for an a cryptocurrency account
+ */
+// <<<pbj.comparable = "shardNum, realmNum, account" >>>
 message AccountID {
     /**
      * The shard number (nonnegative)
@@ -116,6 +141,7 @@ message AccountID {
 /**
  * Identifier for a unique token (or "NFT"), used by both contract and token services.
  */
+// <<<pbj.comparable = "serial_number, token_ID" >>>
 message NftID {
     /**
      * The (non-fungible) token of which this NFT is an instance; uppercase for "ID"
@@ -130,8 +156,9 @@ message NftID {
 }
 
 /**
- * The ID for a file 
+ * The ID for a file
  */
+// <<<pbj.comparable = "shardNum, realmNum, fileNum" >>>
 message FileID {
     /**
      * The shard number (nonnegative)
@@ -150,8 +177,9 @@ message FileID {
 }
 
 /**
- * The ID for a smart contract instance 
+ * The ID for a smart contract instance
  */
+// <<<pbj.comparable = "shardNum, realmNum, contract" >>>
 message ContractID {
     /**
      * The shard number (nonnegative)
@@ -170,21 +198,21 @@ message ContractID {
         int64 contractNum = 3;
 
         /**
-        * The 20-byte EVM address of the contract to call. 
-        * 
+        * The 20-byte EVM address of the contract to call.
+        *
         * Every contract has an EVM address determined by its <tt>shard.realm.num</tt> id.
         * This address is as follows:
         *   <ol>
         *     <li>The first 4 bytes are the big-endian representation of the shard.</li>
         *     <li>The next 8 bytes are the big-endian representation of the realm.</li>
         *     <li>The final 8 bytes are the big-endian representation of the number.</li>
-        *   </ol>  
-        * 
-        * Contracts created via CREATE2 have an <b>additional, primary address</b> that is 
-        * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> 
-        * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id. 
-        * 
-        * (Please do note that CREATE2 contracts can also be referenced by the three-part 
+        *   </ol>
+        *
+        * Contracts created via CREATE2 have an <b>additional, primary address</b> that is
+        * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
+        * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id.
+        *
+        * (Please do note that CREATE2 contracts can also be referenced by the three-part
         * EVM address described above.)
         */
         bytes evm_address = 4;
@@ -208,6 +236,7 @@ message ContractID {
  *  - The scheduled property is true for Scheduled Transactions
  *  - transactionValidStart, accountID and scheduled properties should be omitted
  */
+// <<<pbj.comparable = "transactionValidStart, accountID, scheduled, nonce" >>>
 message TransactionID {
     /**
      * The transaction is invalid if consensusTimestamp < transactionID.transactionStartValid
@@ -225,13 +254,13 @@ message TransactionID {
     bool scheduled = 3;
 
     /**
-     * The identifier for an internal transaction that was spawned as part 
-     * of handling a user transaction. (These internal transactions share the 
+     * The identifier for an internal transaction that was spawned as part
+     * of handling a user transaction. (These internal transactions share the
      * transactionValidStart and accountID of the user transaction, so a
      * nonce is necessary to give them a unique TransactionID.)
-     * 
-     * An example is when a "parent" ContractCreate or ContractCall transaction 
-     * calls one or more HTS precompiled contracts; each of the "child" 
+     *
+     * An example is when a "parent" ContractCreate or ContractCall transaction
+     * calls one or more HTS precompiled contracts; each of the "child"
      * transactions spawned for a precompile has a id with a different nonce.
      */
     int32 nonce = 4;
@@ -240,6 +269,7 @@ message TransactionID {
 /**
  * An account, and the amount that it sends or receives during a cryptocurrency or token transfer.
  */
+// <<<pbj.comparable = "accountID, amount, is_approval" >>>
 message AccountAmount {
     /**
      * The Account ID that sends/receives cryptocurrency or tokens
@@ -276,6 +306,7 @@ message TransferList {
  * NON_FUNGIBLE_UNIQUE type. When minting NFTs the sender will be the default AccountID instance
  * (0.0.0) and when burning NFTs, the receiver will be the default AccountID instance.
  */
+// <<<pbj.comparable = "serialNumber, is_approval, senderAccountID, receiverAccountID" >>>
 message NftTransfer {
     /**
      * The accountID of the sender
@@ -331,6 +362,7 @@ message TokenTransferList {
 /**
  * A rational number, used to set the amount of a value transfer to collect as a custom fee
  */
+// <<<pbj.comparable = "denominator, numerator" >>>
 message Fraction {
     /**
      * The rational's numerator
@@ -346,6 +378,7 @@ message Fraction {
 /**
  * Unique identifier for a topic (used by the consensus service)
  */
+// <<<pbj.comparable = "shardNum, realmNum, topicNum" >>>
 message TopicID {
     /**
      * The shard number (nonnegative)
@@ -364,28 +397,9 @@ message TopicID {
 }
 
 /**
- * Unique identifier for a token
- */
-message TokenID {
-    /**
-     * A nonnegative shard number
-     */
-    int64 shardNum = 1;
-
-    /**
-     * A nonnegative realm number
-     */
-    int64 realmNum = 2;
-
-    /**
-     * A nonnegative token number
-     */
-    int64 tokenNum = 3;
-}
-
-/**
  * Unique identifier for a Schedule
  */
+// <<<pbj.comparable = "shardNum, realmNum, scheduleNum" >>>
 message ScheduleID {
     /**
      * A nonnegative shard number
@@ -426,19 +440,19 @@ enum TokenType {
 }
 
 /**
- * Allows a set of resource prices to be scoped to a certain type of a HAPI operation. 
- * 
+ * Allows a set of resource prices to be scoped to a certain type of a HAPI operation.
+ *
  * For example, the resource prices for a TokenMint operation are different between minting fungible
  * and non-fungible tokens. This enum allows us to "mark" a set of prices as applying to one or the
  * other.
- * 
+ *
  * Similarly, the resource prices for a basic TokenCreate without a custom fee schedule yield a
  * total price of $1. The resource prices for a TokenCreate with a custom fee schedule are different
  * and yield a total base price of $2.
  */
 enum SubType {
     /**
-     * The resource prices have no special scope 
+     * The resource prices have no special scope
      */
     DEFAULT = 0;
 
@@ -552,15 +566,15 @@ enum TokenPauseStatus {
  * A Key can be a public key from either the Ed25519 or ECDSA(secp256k1) signature schemes, where
  * in the ECDSA(secp256k1) case we require the 33-byte compressed form of the public key. We call
  * these public keys <b>primitive keys</b>.
- * 
- * If an account has primitive key associated to it, then the corresponding private key must sign 
- * any transaction to transfer cryptocurrency out of it. 
  *
- * A Key can also be the ID of a smart contract instance, which is then authorized to perform any 
- * precompiled contract action that requires this key to sign. 
+ * If an account has primitive key associated to it, then the corresponding private key must sign
+ * any transaction to transfer cryptocurrency out of it.
  *
- * Note that when a Key is a smart contract ID, it <i>doesn't</i> mean the contract with that ID 
- * will actually create a cryptographic signature. It only means that when the contract calls a 
+ * A Key can also be the ID of a smart contract instance, which is then authorized to perform any
+ * precompiled contract action that requires this key to sign.
+ *
+ * Note that when a Key is a smart contract ID, it <i>doesn't</i> mean the contract with that ID
+ * will actually create a cryptographic signature. It only means that when the contract calls a
  * precompiled contract, the resulting "child transaction" will be authorized to perform any action
  * controlled by the Key.
  *
@@ -624,15 +638,15 @@ message Key {
          */
         bytes ECDSA_secp256k1 = 7;
 
-        /**  
+        /**
          * A smart contract that, if the recipient of the active message frame, should be treated
-         * as having signed. (Note this does not mean the <i>code being executed in the frame</i> 
-         * will belong to the given contract, since it could be running another contract's code via 
+         * as having signed. (Note this does not mean the <i>code being executed in the frame</i>
+         * will belong to the given contract, since it could be running another contract's code via
          * <tt>delegatecall</tt>. So setting this key is a more permissive version of setting the
          * contractID key, which also requires the code in the active message frame belong to the
          * the contract with the given id.)
          */
-        ContractID delegatable_contract_id = 8; 
+        ContractID delegatable_contract_id = 8;
     }
 }
 
@@ -668,7 +682,7 @@ message KeyList {
 }
 
 /**
- * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained 
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
  * here only for historical reasons.
  *
  * Please use the SignaturePair and SignatureMap messages.
@@ -711,7 +725,7 @@ message Signature {
 }
 
 /**
- * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained 
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
  * here only for historical reasons.
  *
  * Please use the SignaturePair and SignatureMap messages.
@@ -727,7 +741,7 @@ message ThresholdSignature {
 }
 
 /**
- * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained 
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
  * here only for historical reasons.
  *
  * Please use the SignaturePair and SignatureMap messages.
@@ -744,16 +758,17 @@ message SignatureList {
 /**
  * The client may use any number of bytes from zero to the whole length of the public key for
  * pubKeyPrefix. If zero bytes are used, then it must be that only one primitive key is required
- * to sign the linked transaction; it will surely resolve to <tt>INVALID_SIGNATURE</tt> otherwise. 
- * 
- * <b>IMPORTANT:</b> In the special case that a signature is being provided for a key used to 
- * authorize a precompiled contract, the <tt>pubKeyPrefix</tt> must contain the <b>entire public 
- * key</b>! That is, if the key is a Ed25519 key, the <tt>pubKeyPrefix</tt> should be 32 bytes 
- * long. If the key is a ECDSA(secp256k1) key, the <tt>pubKeyPrefix</tt> should be 33 bytes long, 
- * since we require the compressed form of the public key. 
- * 
- * Only Ed25519 and ECDSA(secp256k1) keys and hence signatures are currently supported. 
+ * to sign the linked transaction; it will surely resolve to <tt>INVALID_SIGNATURE</tt> otherwise.
+ *
+ * <b>IMPORTANT:</b> In the special case that a signature is being provided for a key used to
+ * authorize a precompiled contract, the <tt>pubKeyPrefix</tt> must contain the <b>entire public
+ * key</b>! That is, if the key is a Ed25519 key, the <tt>pubKeyPrefix</tt> should be 32 bytes
+ * long. If the key is a ECDSA(secp256k1) key, the <tt>pubKeyPrefix</tt> should be 33 bytes long,
+ * since we require the compressed form of the public key.
+ *
+ * Only Ed25519 and ECDSA(secp256k1) keys and hence signatures are currently supported.
  */
+// <<<pbj.comparable = "pubKeyPrefix, signature" >>>
 message SignaturePair {
     /**
      * First few bytes of the public key
@@ -1179,6 +1194,7 @@ enum HederaFunctionality {
  * by the corresponding price to calculate the appropriate fee. Units are one-thousandth of a
  * tinyCent.
  */
+// <<<pbj.comparable = "min, max, constant, bpt, vpt, rbh, sbh, gas, tv, bpr, sbpr" >>>
 message FeeComponents {
     /**
      * A minimum, the calculated fee must be greater than this value
@@ -1262,6 +1278,7 @@ message TransactionFeeSchedule {
  * network for assigning the transaction a consensus timestamp, and a service fee that compensates
  * the network for the ongoing maintenance of the consequences of the transaction.
  */
+// <<<pbj.comparable = "nodedata, networkdata, servicedata, subType" >>>
 message FeeData {
     /**
      * Fee paid to the submitting node
@@ -1322,6 +1339,7 @@ message CurrentAndNextFeeSchedule {
  * Contains the IP address and the port representing a service endpoint of a Node in a network. Used
  * to reach the Hedera API and submit transactions to the network.
  */
+// <<<pbj.comparable = "ipAddressV4, port" >>>
 message ServiceEndpoint {
     /**
      * The 32-bit IPv4 address of the node encoded in left to right order (e.g.  127.0.0.1 has 127
@@ -1338,7 +1356,7 @@ message ServiceEndpoint {
 /**
  * The data about a node, including its service endpoints and the Hedera account to be paid for
  * services provided by the node (that is, queries answered and transactions submitted.)
- * 
+ *
  * If the <tt>serviceEndpoint</tt> list is not set, or empty, then the endpoint given by the
  * (deprecated) <tt>ipAddress</tt> and <tt>portno</tt> fields should be used.
  *
@@ -1364,9 +1382,9 @@ message NodeAddress {
     bytes memo = 3 [deprecated=true];
 
     /**
-     * The node's X509 RSA public key used to sign stream files (e.g., record stream 
-     * files). Precisely, this field is a string of hexadecimal characters which, 
-     * translated to binary, are the public key's DER encoding.  
+     * The node's X509 RSA public key used to sign stream files (e.g., record stream
+     * files). Precisely, this field is a string of hexadecimal characters which,
+     * translated to binary, are the public key's DER encoding.
      */
     string RSA_PubKey = 4;
 
@@ -1381,9 +1399,9 @@ message NodeAddress {
     AccountID nodeAccountId = 6;
 
     /**
-     * # Hash of the node's TLS certificate. Precisely, this field is a string of 
-     * hexadecimal characters which, translated to binary, are the SHA-384 hash of 
-     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be 
+     * # Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be
      * used to verify the node's certificate it presents during TLS negotiations.
      */
     bytes nodeCertHash = 7;
@@ -1421,6 +1439,7 @@ message NodeAddressBook {
  * <tt>NetworkService</tt> to return the deployed versions of both protobufs and software on the
  * node answering the query.
  */
+// <<<pbj.comparable = "major, minor, patch, pre, build" >>>
 message SemanticVersion {
     /**
      * Increases with incompatible API changes
@@ -1456,6 +1475,7 @@ message SemanticVersion {
 /**
  * UNDOCUMENTED
  */
+// <<<pbj.comparable = "name, value, data" >>>
 message Setting {
     /**
      * name of the property
@@ -1486,6 +1506,7 @@ message ServicesConfigurationList {
 /**
  * Token's information related to the given Account
  */
+// <<<pbj.comparable = "tokenId, symbol, balance, decimals, automatic_association, kycStatus, freezeStatus" >>>
 message TokenRelationship {
     /**
      * The ID of the token
@@ -1538,6 +1559,7 @@ message TokenRelationship {
  *
  * Transferable units are not directly comparable across different tokens.
  */
+// <<<pbj.comparable = "tokenId, balance, decimals" >>>
 message TokenBalance {
     /**
      * A unique token id
@@ -1565,6 +1587,7 @@ message TokenBalances {
 }
 
 /* A token - account association */
+// <<<pbj.comparable = "token_id, account_id" >>>
 message TokenAssociation {
     TokenID token_id = 1;  // The token involved in the association
     AccountID account_id = 2; // The account involved in the association
@@ -1573,6 +1596,7 @@ message TokenAssociation {
 /**
  * Staking metadata for an account or a contract returned in CryptoGetInfo or ContractGetInfo queries
  */
+// <<<pbj.comparable = "decline_reward, stake_period_start, staked_id, pending_reward, staked_to_me" >>>
 message StakingInfo {
 
     /**

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -171,10 +171,10 @@ message ContractFunctionResult {
     repeated ContractNonceInfo contract_nonces = 14;
 
     /**
-     * If not null this field specifies what the value of the signer account nonce is post transaction execution. 
+     * If not null this field specifies what the value of the signer account nonce is post transaction execution.
      * For transactions that don't update the signer nonce, this field should be null.
      */
-    Int64Value signer_nonce = 15;
+    google.protobuf.Int64Value signer_nonce = 15;
 }
 
 /**

--- a/services/contract_call_local.proto
+++ b/services/contract_call_local.proto
@@ -169,6 +169,12 @@ message ContractFunctionResult {
      * This is always empty in a ContractCallLocalResponse#ContractFunctionResult message, since no internal creations can happen in a static EVM call.
      */
     repeated ContractNonceInfo contract_nonces = 14;
+
+    /**
+     * If not null this field specifies what the value of the signer account nonce is post transaction execution. 
+     * For transactions that don't update the signer nonce, this field should be null.
+     */
+    Int64Value signer_nonce = 15;
 }
 
 /**

--- a/services/crypto_get_account_balance.proto
+++ b/services/crypto_get_account_balance.proto
@@ -29,7 +29,6 @@ option java_multiple_files = true;
 import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
-import "timestamp.proto";
 
 /**
  * Get the balance of a cryptocurrency account. This returns only the balance, so it is a smaller

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -32,7 +32,6 @@ import "basic_types.proto";
 import "query_header.proto";
 import "response_header.proto";
 import "crypto_add_live_hash.proto";
-import "google/protobuf/wrappers.proto";
 
 /**
  * Get all the information about an account, including the balance. This does not get the list of

--- a/services/custom_fees.proto
+++ b/services/custom_fees.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -33,6 +33,7 @@ import "basic_types.proto";
  * be less than the given minimum_amount, and never greater than the given maximum_amount.  The
  * denomination is always units of the token to which this fractional fee is attached.
  */
+// <<<pbj.comparable = "net_of_transfers,fractional_amount,minimum_amount,maximum_amount" >>>
 message FractionalFee {
   /**
    * The fraction of the transferred units to assess as a fee
@@ -61,6 +62,7 @@ message FractionalFee {
  * A fixed number of units (hbar or token) to assess as a fee during a CryptoTransfer that transfers
  * units of the token to which this fixed fee is attached.
  */
+// <<<pbj.comparable = "denominating_token_id,amount" >>>
 message FixedFee {
   /**
    * The number of units to assess as a fee
@@ -81,24 +83,25 @@ message FixedFee {
  * any fungible value, the ledger will assess the fallback fee, if present, to the new NFT owner.
  * Royalty fees can only be added to tokens of type type NON_FUNGIBLE_UNIQUE.
  *
- * **IMPORTANT:** Users must understand that native royalty fees are _strictly_ a convenience feature, 
- * and that the network cannot enforce inescapable royalties on the exchange of a non-fractional NFT. 
- * For example, if the counterparties agree to split their value transfer and NFT exchange into separate 
- * transactions, the network cannot possibly intervene. (And note the counterparties could use a smart 
+ * **IMPORTANT:** Users must understand that native royalty fees are _strictly_ a convenience feature,
+ * and that the network cannot enforce inescapable royalties on the exchange of a non-fractional NFT.
+ * For example, if the counterparties agree to split their value transfer and NFT exchange into separate
+ * transactions, the network cannot possibly intervene. (And note the counterparties could use a smart
  * contract to make this split transaction atomic if they do not trust each other.)
- * 
- * Counterparties that _do_ wish to respect creator royalties should follow the pattern the network 
- * recognizes: The NFT sender and receiver should both sign a single `CryptoTransfer` that credits 
+ *
+ * Counterparties that _do_ wish to respect creator royalties should follow the pattern the network
+ * recognizes: The NFT sender and receiver should both sign a single `CryptoTransfer` that credits
  * the sender with all the fungible value the receiver is exchanging for the NFT.
- * 
- * Similarly, a marketplace using an approved spender account for an escrow transaction should credit 
- * the account selling the NFT in the same `CryptoTransfer` that deducts fungible value from the buying 
- * account. 
- * 
+ *
+ * Similarly, a marketplace using an approved spender account for an escrow transaction should credit
+ * the account selling the NFT in the same `CryptoTransfer` that deducts fungible value from the buying
+ * account.
+ *
  * There is an [open HIP discussion](https://github.com/hashgraph/hedera-improvement-proposal/discussions/578)
  * that proposes to broaden the class of transactions for which the network automatically collects
  * royalties. If this interests or concerns you, please add your voice to that discussion.
  */
+// <<<pbj.comparable = "exchange_value_fraction,fallback_fee" >>>
 message RoyaltyFee {
   /**
    * The fraction of fungible value exchanged for an NFT to collect as royalty
@@ -117,6 +120,7 @@ message RoyaltyFee {
  * fee is attached. A custom fee may be either fixed or fractional, and must specify a fee collector
  * account to receive the assessed fees. Only positive fees may be assessed.
  */
+// <<<pbj.comparable = "fee_collector_account_id,all_collectors_are_exempt,fee" >>>
 message CustomFee {
   oneof fee {
     /**
@@ -143,7 +147,7 @@ message CustomFee {
   /**
    * If true, exempts all the token's fee collection accounts from this fee.
    * (The token's treasury and the above fee_collector_account_id will always
-   * be exempt. Please see <a href="https://hips.hedera.com/hip/hip-573">HIP-573</a> 
+   * be exempt. Please see <a href="https://hips.hedera.com/hip/hip-573">HIP-573</a>
    * for details.)
    */
   bool all_collectors_are_exempt = 5;

--- a/services/duration.proto
+++ b/services/duration.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 /**
  * A length of time in seconds.
  */
+// <<<pbj.comparable = "seconds" >>>
 message Duration {
     /**
      * The number of seconds

--- a/services/exchange_rate.proto
+++ b/services/exchange_rate.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
@@ -30,8 +30,9 @@ import "timestamp.proto";
 
 /**
  * An exchange rate between hbar and cents (USD) and the time at which the exchange rate will
- * expire, and be superseded by a new exchange rate. 
+ * expire, and be superseded by a new exchange rate.
  */
+// <<<pbj.comparable = "expirationTime,hbarEquiv,centEquiv" >>>
 message ExchangeRate {
     /**
      * Denominator in calculation of exchange rate between hbar and cents
@@ -52,6 +53,7 @@ message ExchangeRate {
 /**
  * Two sets of exchange rates
  */
+// <<<pbj.comparable = "currentRate,nextRate" >>>
 message ExchangeRateSet {
     /**
      * Current exchange rate

--- a/services/freeze.proto
+++ b/services/freeze.proto
@@ -26,7 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.freeze">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-import "duration.proto";
 import "timestamp.proto";
 import "basic_types.proto";
 import "freeze_type.proto";

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1373,9 +1373,4 @@ enum ResponseCodeEnum {
    * An alias that is assigned to an account or contract cannot be assigned to another account or contract.
    */
   ALIAS_ALREADY_ASSIGNED = 332;
-
-  /**
-   * A provided metadata key was invalid. Verify the bytes for an Ed25519 public key are exactly 32 bytes; and the bytes for a compressed ECDSA(secp256k1) key are exactly 33 bytes, with the first byte either 0x02 or 0x03..
-   */
-  INVALID_METADATA_KEY = 333;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1373,4 +1373,9 @@ enum ResponseCodeEnum {
    * An alias that is assigned to an account or contract cannot be assigned to another account or contract.
    */
   ALIAS_ALREADY_ASSIGNED = 332;
+
+  /**
+   * A provided metadata key was invalid. Verify the bytes for an Ed25519 public key are exactly 32 bytes; and the bytes for a compressed ECDSA(secp256k1) key are exactly 33 bytes, with the first byte either 0x02 or 0x03..
+   */
+  INVALID_METADATA_KEY = 333;
 }

--- a/services/response_header.proto
+++ b/services/response_header.proto
@@ -26,7 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-import "transaction_response.proto";
 import "query_header.proto";
 import "response_code.proto";
 

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -29,7 +29,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * Information about the most recently completed and last 256 blocks.
+ * Information about ongoing, most recently completed, and last 256 blocks.
  */
 message BlockInfo {
   /**
@@ -47,4 +47,16 @@ message BlockInfo {
    * If we are shortly after genesis and there are less than 256 blocks then this could contain less than 256 hashes.
    */
   bytes block_hashes = 3;
+  /**
+   * The consensus time of the last transaction that was handled by the node. This property is how we 'advance the
+   * consensus clock', i.e. continually setting this property to the latest consensus timestamp (and thus transaction)
+   * handled by the node.
+   */
+  Timestamp cons_time_of_last_handled_txn = 4;
+  /**
+   * A flag indicating whether migration records have been published. This property should be marked 'false'
+   * immediately following a node upgrade, and marked 'true' once the migration records (if any) are published, which
+   * should happen during the first transaction handled by the node.
+   */
+  bool migration_records_streamed = 5;
 }

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -59,4 +59,9 @@ message BlockInfo {
    * should happen during the first transaction handled by the node.
    */
   bool migration_records_streamed = 5;
+  /**
+   * The consensus time of the first transaction in the current block; necessary for reconnecting nodes to detect
+   * when the current block is finished.
+   */
+  Timestamp first_cons_time_of_current_block = 6;
 }

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.blockrecords">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Information about the most recently completed and last 256 blocks.
+ */
+message BlockInfo {
+  /**
+   * The last block number, this is the last completed immutable block.
+   */
+  int64 last_block_no = 1;
+  /**
+   * The consensus time of the first transaction of the last block, this is the last completed immutable block.
+   */
+  Timestamp first_cons_time_of_last_block = 2;
+  /**
+   * SHA384 48 byte hashes of the last 256 blocks in single byte array.
+   * First 48 bytes is the oldest block.
+   * Last 48 bytes is the newest block, which is the last fully completed immutable block.
+   * If we are shortly after genesis and there are less than 256 blocks then this could contain less than 256 hashes.
+   */
+  bytes block_hashes = 3;
+}

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "timestamp.proto";
@@ -31,6 +31,7 @@ option java_multiple_files = true;
 /**
  * Information about ongoing, most recently completed, and last 256 blocks.
  */
+// <<<pbj.comparable = "last_block_number,first_cons_time_of_last_block,cons_time_of_last_handled_txn,migration_records_streamed,block_hashes" >>>
 message BlockInfo {
   /**
    * The last block number, this is the last completed immutable block.

--- a/services/state/blockrecords/block_info.proto
+++ b/services/state/blockrecords/block_info.proto
@@ -35,7 +35,7 @@ message BlockInfo {
   /**
    * The last block number, this is the last completed immutable block.
    */
-  int64 last_block_no = 1;
+  int64 last_block_number = 1;
   /**
    * The consensus time of the first transaction of the last block, this is the last completed immutable block.
    */

--- a/services/state/blockrecords/running_hashes.proto
+++ b/services/state/blockrecords/running_hashes.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.blockrecords">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The running hash of a transaction records and the previous 3 running hashes. All hashes are 48 bytes SHA384 hashes. If the
+ * running hashes do not exist yet then they will be default values witch is empty bytes object or zero length byte array.
+ */
+message RunningHashes {
+  /**
+   * A running hash of all record stream items
+   */
+  bytes running_hash = 1;
+  /**
+   * The previous running hash of all record stream items
+   */
+  bytes n_minus_1_running_hash = 2;
+  /**
+   * The previous, previous running hash of all record stream items
+   */
+  bytes n_minus_2_running_hash = 3;
+  /**
+   * The previous, previous, previous running hash of all record stream items
+   */
+  bytes n_minus_3_running_hash = 4;
+}

--- a/services/state/blockrecords/running_hashes.proto
+++ b/services/state/blockrecords/running_hashes.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -28,8 +28,9 @@ option java_multiple_files = true;
 
 /**
  * The running hash of a transaction records and the previous 3 running hashes. All hashes are 48 bytes SHA384 hashes. If the
- * running hashes do not exist yet then they will be default values witch is empty bytes object or zero length byte array.
+ * running hashes do not exist yet then they will be default values which is empty bytes object or zero length byte array.
  */
+// <<<pbj.comparable = "running_hash,n_minus_1_running_hash,n_minus_2_running_hash,n_minus_3_running_hash" >>>
 message RunningHashes {
   /**
    * A running hash of all record stream items

--- a/services/state/common.proto
+++ b/services/state/common.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.common">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single 64-bit number identifying a Hedera native entity.
+ */
+message EntityNumber {
+    int64 number = 1;
+}
+
+/**
+ * Identifier for a unique token (or "NFT"), used by both contract and token services.
+ */
+message UniqueTokenId {
+  /**
+   * The number of the unique token type this NFT is an instance of.
+   */
+  int64 token_type_number = 1;
+
+  /**
+   * The serial number of this NFT within its token type.
+   */
+  int64 serial_number = 2;
+}

--- a/services/state/common.proto
+++ b/services/state/common.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "basic_types.proto";
 
 package proto;
 
@@ -34,13 +35,21 @@ message EntityNumber {
 }
 
 /**
+ * Pair of AccountID and TokenID to represent TokenRelation
+ */
+message EntityIDPair {
+  AccountID account_id = 1;
+  TokenID token_id = 2;
+}
+
+/**
  * Identifier for a unique token (or "NFT"), used by both contract and token services.
  */
 message UniqueTokenId {
   /**
-   * The number of the unique token type this NFT is an instance of.
+   * The id of the unique token type this NFT is an instance of.
    */
-  int64 token_type_number = 1;
+  TokenID token_id = 1;
 
   /**
    * The serial number of this NFT within its token type.

--- a/services/state/common.proto
+++ b/services/state/common.proto
@@ -41,18 +41,3 @@ message EntityIDPair {
   AccountID account_id = 1;
   TokenID token_id = 2;
 }
-
-/**
- * Identifier for a unique token (or "NFT"), used by both contract and token services.
- */
-message UniqueTokenId {
-  /**
-   * The id of the unique token type this NFT is an instance of.
-   */
-  TokenID token_id = 1;
-
-  /**
-   * The serial number of this NFT within its token type.
-   */
-  int64 serial_number = 2;
-}

--- a/services/state/common.proto
+++ b/services/state/common.proto
@@ -4,11 +4,11 @@ import "basic_types.proto";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,7 +20,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -30,6 +30,7 @@ option java_multiple_files = true;
 /**
  * A single 64-bit number identifying a Hedera native entity.
  */
+// <<<pbj.comparable = "number" >>>
 message EntityNumber {
     int64 number = 1;
 }
@@ -37,6 +38,7 @@ message EntityNumber {
 /**
  * Pair of AccountID and TokenID to represent TokenRelation
  */
+// <<<pbj.comparable = "account_id,token_id" >>>
 message EntityIDPair {
   AccountID account_id = 1;
   TokenID token_id = 2;

--- a/services/state/congestion/congestion_level_starts.proto
+++ b/services/state/congestion/congestion_level_starts.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.congestion">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+message CongestionLevelStarts {
+  /**
+   * Timestamps defining generic congestion levels.
+   */
+  repeated Timestamp generic_level_starts = 1;
+
+  /**
+   * Timestamps defining gas congestion levels.
+   */
+  repeated Timestamp gas_level_starts = 2;
+}

--- a/services/state/congestion/congestion_level_starts.proto
+++ b/services/state/congestion/congestion_level_starts.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "timestamp.proto";

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -68,10 +68,10 @@ message Topic {
      */
     int64 auto_renew_period = 4;
     /**
-     * The number of the account (if any) that the network will attempt to charge for the 
+     * The id of the account (if any) that the network will attempt to charge for the
      * topic's auto-renewal upon expiration.
      */
-    int64 auto_renew_account_number = 5;
+    AccountID auto_renew_account_id = 5;
     /**
      * Whether this topic is deleted.
      */

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -29,7 +29,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Consensus Service topic in the network Merkle tree. 
+ * Representation of a Hedera Consensus Service topic in the network Merkle tree.
  * 
  * As with all network entities, a topic has a unique entity number, which is usually given along 
  * with the network's shard and realm in the form of a shard.realm.number id.
@@ -51,9 +51,9 @@ option java_multiple_files = true;
  */
 message Topic {
     /**
-     * The topic's unique id number in the Merkle state.
+     * The topic's unique id in the Merkle state.
      */
-    TopicID id = 1;
+    TopicID topic_id = 1;
     /**
      * The number of messages sent to the topic.
      */
@@ -61,7 +61,7 @@ message Topic {
     /**
      * The topic's consensus expiration time in seconds since the epoch.
      */
-    int64 expiry = 3;
+    int64 expiration_second = 3;
     /**
      * The number of seconds for which the topic will be automatically renewed 
      * upon expiring (if it has a valid auto-renew account).

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -51,9 +51,9 @@ option java_multiple_files = true;
  */
 message Topic {
     /**
-     * The topic's unique entity number in the Merkle state.
+     * The topic's unique id number in the Merkle state.
      */
-    int64 topic_number = 1;
+    TopicID id = 1;
     /**
      * The number of messages sent to the topic.
      */

--- a/services/state/consensus/topic.proto
+++ b/services/state/consensus/topic.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";
@@ -30,19 +30,19 @@ option java_multiple_files = true;
 
 /**
  * Representation of a Hedera Consensus Service topic in the network Merkle tree.
- * 
- * As with all network entities, a topic has a unique entity number, which is usually given along 
+ *
+ * As with all network entities, a topic has a unique entity number, which is usually given along
  * with the network's shard and realm in the form of a shard.realm.number id.
- * 
+ *
  * A topic consists of just two pieces of data:
  *   1. The total number of messages sent to the topic; and,
  *   2. The running hash of all those messages.
  * It also has several metadata elements:
  *   1. A consensus expiration time in seconds since the epoch.
- *   2. (Optional) The number of an auto-renew account, in the same shard and realm as the topic, that 
- *   has signed a transaction allowing the network to use its balance to automatically extend the topic's 
+ *   2. (Optional) The number of an auto-renew account, in the same shard and realm as the topic, that
+ *   has signed a transaction allowing the network to use its balance to automatically extend the topic's
  *   expiration time when it passes.
- *   3. The number of seconds the network should automatically extend the topic's expiration by, if the 
+ *   3. The number of seconds the network should automatically extend the topic's expiration by, if the
  *   topic has a valid auto-renew account, and is not deleted upon expiration.
  *   4. A boolean marking if the topic has been deleted.
  *   5. A memo string whose UTF-8 encoding is at most 100 bytes.
@@ -63,7 +63,7 @@ message Topic {
      */
     int64 expiration_second = 3;
     /**
-     * The number of seconds for which the topic will be automatically renewed 
+     * The number of seconds for which the topic will be automatically renewed
      * upon expiring (if it has a valid auto-renew account).
      */
     int64 auto_renew_period = 4;
@@ -80,7 +80,7 @@ message Topic {
      * When a topic is created, its running hash is initialized to 48 bytes of binary zeros.
      * For each submitted message, the topic's running hash is then updated to the output
      * of a particular SHA-384 digest whose input data include the previous running hash.
-     * 
+     *
      * See the TransactionReceipt.proto documentation for an exact description of the
      * data included in the SHA-384 digest used for the update.
      */

--- a/services/state/contract/bytecode.proto
+++ b/services/state/contract/bytecode.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The bytecode for a contract id.
+ */
+message Bytecode {
+    /**
+     * The raw bytes (not hex-encoded) of a contract's bytecode.
+     */
+    bytes code = 1;
+}

--- a/services/state/contract/bytecode.proto
+++ b/services/state/contract/bytecode.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -29,6 +29,7 @@ option java_multiple_files = true;
 /**
  * The bytecode for a contract id.
  */
+// <<<pbj.comparable = "code" >>>
 message Bytecode {
     /**
      * The raw bytes (not hex-encoded) of a contract's bytecode.

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "state/common.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The key of a storage slot. A slot is scoped to a specific contract number.
+ * 
+ * For each contract, its EVM storage is a mapping of 256-bit keys (or "words") to 256-bit values. 
+ */
+message SlotKey {
+    /**
+     * The number of the contract whose storage this slot belongs to.
+     */
+    int64 contract_number = 1;
+
+    /**
+     * The EVM key of this slot, when left-padded with zeros to form a 256-bit word.
+     */
+    bytes key = 2;
+}
+
+/**
+ * The value of a contract storage slot. For the EVM, this is a single word.
+ * 
+ * But because we need to be able to iterate through all the storage slots for an 
+ * expired contract when purging it from state, our slot values also include the words 
+ * of the previous and next keys in this contract's storage "list". 
+ */
+message SlotValue {
+    /**
+     * The EVM value in this slot, when left-padded with zeros to form a 256-bit word.
+     */
+    bytes value = 1;
+
+    /**
+     * The word of the previous key in this contract's storage list (if any).
+     */
+    bytes previous_key = 2;
+
+    /**
+     * The word of the next key in this contract's storage list (if any).
+     */
+    bytes next_key = 3;
+}

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -26,6 +26,8 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
+import "basic_types.proto";
+
 /**
  * The key of a storage slot. A slot is scoped to a specific contract number.
  * 
@@ -35,7 +37,7 @@ message SlotKey {
     /**
      * The number of the contract whose storage this slot belongs to.
      */
-    int64 contract_number = 1;
+    ContractID contractID = 1;
 
     /**
      * The EVM key of this slot, when left-padded with zeros to form a 256-bit word.

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
+/*
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -30,9 +30,10 @@ import "basic_types.proto";
 
 /**
  * The key of a storage slot. A slot is scoped to a specific contract number.
- * 
- * For each contract, its EVM storage is a mapping of 256-bit keys (or "words") to 256-bit values. 
+ *
+ * For each contract, its EVM storage is a mapping of 256-bit keys (or "words") to 256-bit values.
  */
+// <<<pbj.comparable = "contractID,key" >>>
 message SlotKey {
     /**
      * The number of the contract whose storage this slot belongs to.
@@ -47,11 +48,12 @@ message SlotKey {
 
 /**
  * The value of a contract storage slot. For the EVM, this is a single word.
- * 
+ *
  * Because we iterate through all the storage slots for an expired contract
  * when purging it from state, our slot values also include the words
- * of the previous and next keys in this contract's storage "list". 
+ * of the previous and next keys in this contract's storage "list".
  */
+// <<<pbj.comparable = "value,previous_key,next_key" >>>
 message SlotValue {
     /**
      * The EVM value in this slot, when left-padded with zeros to form a 256-bit word.

--- a/services/state/contract/storage_slot.proto
+++ b/services/state/contract/storage_slot.proto
@@ -22,8 +22,6 @@ package proto;
  * ‍
  */
 
-import "state/common.proto";
-
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
@@ -48,8 +46,8 @@ message SlotKey {
 /**
  * The value of a contract storage slot. For the EVM, this is a single word.
  * 
- * But because we need to be able to iterate through all the storage slots for an 
- * expired contract when purging it from state, our slot values also include the words 
+ * Because we iterate through all the storage slots for an expired contract
+ * when purging it from state, our slot values also include the words
  * of the previous and next keys in this contract's storage "list". 
  */
 message SlotValue {

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -59,4 +59,9 @@ message File {
      * Whether this file is deleted.
      */
     bool deleted = 6;
+    /**
+      * The pre system delete expiration time in seconds
+      */
+    int64 pre_system_delete_expiration_second = 7;
+
 }

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -45,8 +45,7 @@ message File {
       */
     int64 expiration_time = 2;
     /**
-     * All keys at the top level of a key list must sign to create or modify the file. Any one of
-     * the keys at the top level key list can sign to delete the file.
+     * All keys at the top level of a key list must sign to create, modify and delete the file.
      */
     KeyList keys = 3;
     /**

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service file in the network Merkle tree.
+ *
+ * As with all network entities, a file has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+message File {
+    /**
+     * The file's unique entity number in the Merkle state.
+     */
+    int64 file_number = 1;
+    /**
+      * The file's consensus expiration time in seconds since the epoch.
+      */
+    int64 expiration_time = 2;
+    /**
+     * All keys at the top level of a key list must sign to create or modify the file. Any one of
+     * the keys at the top level key list can sign to delete the file.
+     */
+    KeyList keys = 3;
+    /**
+     * The bytes that are the contents of the file
+     */
+    bytes contents = 4;
+    /**
+     * The memo associated with the file (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 5;
+    /**
+     * Whether this file is deleted.
+     */
+    bool deleted = 6;
+}

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -37,9 +37,9 @@ option java_multiple_files = true;
  */
 message File {
     /**
-     * The file's unique entity number in the Merkle state.
+     * The file's unique file identifier in the Merkle state.
      */
-    int64 file_number = 1;
+    FileID file_id = 1;
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */

--- a/services/state/file/file.proto
+++ b/services/state/file/file.proto
@@ -23,16 +23,15 @@ package proto;
  */
 
 import "basic_types.proto";
-import "timestamp.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service file in the network Merkle tree.
+ * Representation of a Hedera Token Service file in the network Merkle tree.
  *
- * As with all network entities, a file has a unique entity number, which is usually given along
+ * As with all network entities, a file has a unique entity number, which is given along
  * with the network's shard and realm in the form of a shard.realm.number id.
  */
 message File {
@@ -43,7 +42,7 @@ message File {
     /**
       * The file's consensus expiration time in seconds since the epoch.
       */
-    int64 expiration_time = 2;
+    int64 expiration_second = 2;
     /**
      * All keys at the top level of a key list must sign to create, modify and delete the file.
      */

--- a/services/state/primitives.proto
+++ b/services/state/primitives.proto
@@ -24,8 +24,8 @@ package proto;
  * type instead.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java.primitive";
-// <<<pbj.java_package = "com.hedera.hapi.node.state.primitive">>> This comment is special code for setting PBJ Compiler java package
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.primitives">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**

--- a/services/state/primitives.proto
+++ b/services/state/primitives.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package proto;
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This proto file contains primitive value messages.
+ * These are intended only for situations where the entire value to be stored in state is a single
+ * primitive.  These should never be used as components of another message; use the protobuf
+ * type instead.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java.primitive";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.primitive">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single 64-bit number with no particular meaning.
+ */
+message ProtoLong {
+    int64 value = 1;
+}
+
+/**
+ * A single 32-bit number with no particular meaning.
+ */
+message ProtoInteger {
+    int32 value = 1;
+}
+
+/**
+ * A single boolean with no particular meaning.
+ */
+message ProtoBoolean {
+    bool value = 1;
+}
+
+/**
+ * A single string with no particular meaning.
+ */
+message ProtoString {
+    string value = 1;
+}
+
+/**
+ * A single byte array with no particular meaning.
+ */
+message ProtoBytes {
+    bytes value = 1;
+}
+

--- a/services/state/primitives.proto
+++ b/services/state/primitives.proto
@@ -31,6 +31,7 @@ option java_multiple_files = true;
 /**
  * A single 64-bit number with no particular meaning.
  */
+// <<<pbj.comparable = "value" >>>
 message ProtoLong {
     int64 value = 1;
 }
@@ -38,6 +39,7 @@ message ProtoLong {
 /**
  * A single 32-bit number with no particular meaning.
  */
+// <<<pbj.comparable = "value" >>>
 message ProtoInteger {
     int32 value = 1;
 }
@@ -45,6 +47,7 @@ message ProtoInteger {
 /**
  * A single boolean with no particular meaning.
  */
+// <<<pbj.comparable = "value" >>>
 message ProtoBoolean {
     bool value = 1;
 }
@@ -52,6 +55,7 @@ message ProtoBoolean {
 /**
  * A single string with no particular meaning.
  */
+// <<<pbj.comparable = "value" >>>
 message ProtoString {
     string value = 1;
 }
@@ -59,7 +63,7 @@ message ProtoString {
 /**
  * A single byte array with no particular meaning.
  */
+// <<<pbj.comparable = "value" >>>
 message ProtoBytes {
     bytes value = 1;
 }
-

--- a/services/state/recordcache/recordcache.proto
+++ b/services/state/recordcache/recordcache.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";

--- a/services/state/recordcache/recordcache.proto
+++ b/services/state/recordcache/recordcache.proto
@@ -22,6 +22,7 @@ package proto;
  * ‍
  */
 
+import "basic_types.proto";
 import "transaction_record.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -41,7 +42,14 @@ message TransactionRecordEntry {
     int64 node_id = 1;
 
     /**
+     * The AccountID of the payer of the transaction. This may be the same as the account ID within the Transaction ID
+     * of the record, or it may be the account ID of the node that submitted the transaction to consensus if the account
+     * ID in the Transaction ID is not able to pay.
+     */
+    AccountID payer_account_id = 2;
+
+    /**
      * The transaction record for the transaction.
      */
-    TransactionRecord transaction_record = 2;
+    TransactionRecord transaction_record = 3;
 }

--- a/services/state/recordcache/recordcache.proto
+++ b/services/state/recordcache/recordcache.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "transaction_record.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.recordcache">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * As transactions are handled and records and receipts are created, they are stored in state for a configured time
+ * limit (perhaps, for example, 3 minutes). During this time window, any client can query the node and get the record
+ * or receipt for the transaction. The TransactionRecordEntry is the object stored in state with this information.
+ */
+message TransactionRecordEntry {
+    /**
+     * The ID of the node that submitted the transaction to consensus. The ID is the ID of the node as known by the
+     * address book. Valid node IDs are in the range 0..2^63-1, inclusive.
+     */
+    int64 node_id = 1;
+
+    /**
+     * The transaction record for the transaction.
+     */
+    TransactionRecord transaction_record = 2;
+}

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -25,13 +25,14 @@ package proto;
 import "basic_types.proto";
 import "timestamp.proto";
 import "schedulable_transaction_body.proto";
+import "transaction_body.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.schedule">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Schedule Service in the network Merkle tree.
+ * Representation of a Hedera Schedule entry in the network Merkle tree.
  *
  * As with all network entities, a schedule has a unique entity number, which is usually given along
  * with the network's shard and realm in the form of a shard.realm.number id.
@@ -40,11 +41,13 @@ message Schedule {
 
     /**
      * The schedule deleted flag
+     * A schedule will either be executed or deleted, but never both.
      */
     bool deleted = 1;
 
     /**
      * The schedule executed flag
+     * A schedule will either be executed or deleted, but never both.
      */
     bool executed = 2;
 
@@ -54,54 +57,64 @@ message Schedule {
     string memo = 3;
 
     /**
-     * This schedule's unique ID within the network state.
+     * This schedule's unique ID within the global network state.
      */
     ScheduleID id = 4;
 
     /**
-     * The schedule account for this schedule.
+     * The schedule account for this schedule.  This is the account that submitted the original
+     * ScheduleCreate transaction.
      */
     AccountID scheduler_account = 5;
 
     /**
-     * The payer account for this schedule.
+     * The explicit payer account for the scheduled transaction.
+     * This account is added to the accounts that must sign the schedule before it will execute.
      */
     AccountID payer_account = 6;
 
     /**
-      * The admin key for this schedule.
+     * The admin key for this schedule.
+     * If this is not set, then the schedule cannot be deleted.
      */
     Key admin_key = 7;
 
     /**
-      * The start time of the schedule.
+     * The transaction valid start value from the transaction that created this schedule.
      */
     Timestamp schedule_valid_start = 8;
 
     /**
-      * The expiration time of the schedule as provided by the user.
+     * The requested expiration time of the schedule as provided by the user.
+     * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
     Timestamp expiration_time_provided = 9;
 
     /**
-      * The calculated expiration time of the schedule.
+     * The calculated expiration time of the schedule.  This is calculated based on the requested
+     * expiration time from the create transaction, and the maximum expiration permitted by the
+     * network.
+     * The schedule will be removed from global network state after the network reaches a consensus
+     * time greater than or equal to this value.
      */
     Timestamp calculated_expiration_time = 10;
 
     /**
-      * The consensus timestamp of the transaction that executed, deleted, or expired this schedule.
+     * The consensus timestamp of the transaction that executed or deleted this schedule.
      */
     Timestamp resolution_time = 11;
 
     /**
-     * The scheduled transaction
+     * The scheduled transaction to execute.
      */
     SchedulableTransactionBody scheduled_transaction = 12;
 
     /**
-     * The transaction body bytes
+     * The full transaction that created this schedule.  This is primarily used for duplicate
+     * schedule create detection.  This is also the source of the parent transaction ID, from
+     * which the child transaction ID is derived.
      */
-    bytes body_bytes = 13;
+    TransactionBody original_create_transaction = 13;
 
     /**
      * All the primitive keys that have already signed this schedule.

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -24,6 +24,7 @@ package proto;
 
 import "basic_types.proto";
 import "timestamp.proto";
+import "schedulable_transaction_body.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
@@ -95,7 +96,7 @@ message Schedule {
     /**
      * The scheduled transaction
      */
-    SchedulableTransaction scheduled_transaction = 12;
+    SchedulableTransactionBody scheduled_transaction = 12;
 
     /**
      * The transaction body bytes

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
- * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";
@@ -27,7 +27,7 @@ import "timestamp.proto";
 import "schedulable_transaction_body.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
-// <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
+// <<<pbj.java_package = "com.hedera.hapi.node.state.schedule">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 /**

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -38,18 +38,22 @@ option java_multiple_files = true;
  * with the network's shard and realm in the form of a shard.realm.number id.
  */
 message Schedule {
+    /**
+     * This schedule's unique ID within the global network state.
+     */
+    ScheduleID schedule_id = 1;
 
     /**
      * The schedule deleted flag
      * A schedule will either be executed or deleted, but never both.
      */
-    bool deleted = 1;
+    bool deleted = 2;
 
     /**
      * The schedule executed flag
      * A schedule will either be executed or deleted, but never both.
      */
-    bool executed = 2;
+    bool executed = 3;
 
     /**
      * The schedule flag to wait for expiration
@@ -61,29 +65,24 @@ message Schedule {
      * Note that a schedule is always removed from state when it expires, regardless of whether it
      * was executed or not.
      */
-    bool wait_for_expiry = 3;
+    bool wait_for_expiry = 4;
 
     /**
      * The memo associated with this schedule.
      */
-    string memo = 4;
-
-    /**
-     * This schedule's unique ID within the global network state.
-     */
-    ScheduleID id = 5;
+    string memo = 5;
 
     /**
      * The schedule account for this schedule.  This is the account that submitted the original
      * ScheduleCreate transaction.
      */
-    AccountID scheduler_account = 6;
+    AccountID scheduler_account_id = 6;
 
     /**
      * The explicit payer account for the scheduled transaction.
      * This account is added to the accounts that must sign the schedule before it will execute.
      */
-    AccountID payer_account = 7;
+    AccountID payer_account_id = 7;
 
     /**
      * The admin key for this schedule.
@@ -100,7 +99,7 @@ message Schedule {
      * The requested expiration time of the schedule as provided by the user.
      * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
-    Timestamp expiration_time_provided = 10;
+    int64 provided_expiration_second = 10;
 
     /**
      * The calculated expiration time of the schedule.  This is calculated based on the requested
@@ -109,7 +108,7 @@ message Schedule {
      * The schedule will be removed from global network state after the network reaches a consensus
      * time greater than or equal to this value.
      */
-    Timestamp calculated_expiration_time = 11;
+    int64 calculated_expiration_second = 11;
 
     /**
      * The consensus timestamp of the transaction that executed or deleted this schedule.
@@ -145,5 +144,5 @@ message ScheduleList {
   /**
    * a list of schedules, in no particular order.
    */
-  repeated Schedule schedules = 2;
+  repeated Schedule schedules = 1;
 }

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -52,43 +52,55 @@ message Schedule {
     bool executed = 2;
 
     /**
+     * The schedule flag to wait for expiration
+     * A schedule will be executed immediately when all necessary signatures are gathered, unless
+     * this flag is set.  If this flag is set, the schedule will wait until the consensus time
+     * reaches expiration_time_provided, when signatures will again be verified, and if all
+     * required signatures are present at that time, the schedule will be executed.  Otherwise
+     * the schedule will expire without execution.
+     * Note that a schedule is always removed from state when it expires, regardless of whether it
+     * was executed or not.
+     */
+    bool wait_for_expiry = 3;
+
+    /**
      * The memo associated with this schedule.
      */
-    string memo = 3;
+    string memo = 4;
 
     /**
      * This schedule's unique ID within the global network state.
      */
-    ScheduleID id = 4;
+    ScheduleID id = 5;
 
     /**
      * The schedule account for this schedule.  This is the account that submitted the original
      * ScheduleCreate transaction.
      */
-    AccountID scheduler_account = 5;
+    AccountID scheduler_account = 6;
 
     /**
      * The explicit payer account for the scheduled transaction.
      * This account is added to the accounts that must sign the schedule before it will execute.
      */
-    AccountID payer_account = 6;
+    AccountID payer_account = 7;
 
     /**
      * The admin key for this schedule.
      * If this is not set, then the schedule cannot be deleted.
      */
-    Key admin_key = 7;
+    Key admin_key = 8;
 
     /**
      * The transaction valid start value from the transaction that created this schedule.
      */
-    Timestamp schedule_valid_start = 8;
+    Timestamp schedule_valid_start = 9;
 
     /**
      * The requested expiration time of the schedule as provided by the user.
      * The actual calculated expiration time may be "earlier" than this, but will not be later.
      */
-    Timestamp expiration_time_provided = 9;
+    Timestamp expiration_time_provided = 10;
 
     /**
      * The calculated expiration time of the schedule.  This is calculated based on the requested
@@ -97,29 +109,29 @@ message Schedule {
      * The schedule will be removed from global network state after the network reaches a consensus
      * time greater than or equal to this value.
      */
-    Timestamp calculated_expiration_time = 10;
+    Timestamp calculated_expiration_time = 11;
 
     /**
      * The consensus timestamp of the transaction that executed or deleted this schedule.
      */
-    Timestamp resolution_time = 11;
+    Timestamp resolution_time = 12;
 
     /**
      * The scheduled transaction to execute.
      */
-    SchedulableTransactionBody scheduled_transaction = 12;
+    SchedulableTransactionBody scheduled_transaction = 13;
 
     /**
      * The full transaction that created this schedule.  This is primarily used for duplicate
      * schedule create detection.  This is also the source of the parent transaction ID, from
      * which the child transaction ID is derived.
      */
-    TransactionBody original_create_transaction = 13;
+    TransactionBody original_create_transaction = 14;
 
     /**
      * All the primitive keys that have already signed this schedule.
      * The scheduled transaction will not be executed before this list is
      * sufficient to "activate" the required keys for the scheduled transaction.
      */
-    repeated Key signatories = 14;
+    repeated Key signatories = 15;
 }

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -75,22 +75,22 @@ message Schedule {
     /**
       * The start time of the schedule.
      */
-    TimeStamp schedule_valid_start = 8;
+    Timestamp schedule_valid_start = 8;
 
     /**
       * The expiration time of the schedule as provided by the user.
      */
-    TimeStamp expiration_time_provided = 9;
+    Timestamp expiration_time_provided = 9;
 
     /**
       * The calculated expiration time of the schedule.
      */
-    TimeStamp calculated_expiration_time = 10;
+    Timestamp calculated_expiration_time = 10;
 
     /**
       * The consensus timestamp of the transaction that executed, deleted, or expired this schedule.
      */
-    TimeStamp resolution_time = 11;
+    Timestamp resolution_time = 11;
 
     /**
      * The scheduled transaction

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -135,3 +135,15 @@ message Schedule {
      */
     repeated Key signatories = 15;
 }
+
+/**
+ * A message for storing a list of schedules in state.
+ * This is used to store lists of schedules that expire at a particular time or that have the same
+ * simplified hash code.
+ */
+message ScheduleList {
+  /**
+   * a list of schedules, in no particular order.
+   */
+  repeated Schedule schedules = 2;
+}

--- a/services/state/schedule/schedule.proto
+++ b/services/state/schedule/schedule.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Schedule Service in the network Merkle tree.
+ *
+ * As with all network entities, a schedule has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+message Schedule {
+
+    /**
+     * The schedule deleted flag
+     */
+    bool deleted = 1;
+
+    /**
+     * The schedule executed flag
+     */
+    bool executed = 2;
+
+    /**
+     * The memo associated with this schedule.
+     */
+    string memo = 3;
+
+    /**
+     * This schedule's unique ID within the network state.
+     */
+    ScheduleID id = 4;
+
+    /**
+     * The schedule account for this schedule.
+     */
+    AccountID scheduler_account = 5;
+
+    /**
+     * The payer account for this schedule.
+     */
+    AccountID payer_account = 6;
+
+    /**
+      * The admin key for this schedule.
+     */
+    Key admin_key = 7;
+
+    /**
+      * The start time of the schedule.
+     */
+    TimeStamp schedule_valid_start = 8;
+
+    /**
+      * The expiration time of the schedule as provided by the user.
+     */
+    TimeStamp expiration_time_provided = 9;
+
+    /**
+      * The calculated expiration time of the schedule.
+     */
+    TimeStamp calculated_expiration_time = 10;
+
+    /**
+      * The consensus timestamp of the transaction that executed, deleted, or expired this schedule.
+     */
+    TimeStamp resolution_time = 11;
+
+    /**
+     * The scheduled transaction
+     */
+    SchedulableTransaction scheduled_transaction = 12;
+
+    /**
+     * The transaction body bytes
+     */
+    bytes body_bytes = 13;
+
+    /**
+     * All the primitive keys that have already signed this schedule.
+     * The scheduled transaction will not be executed before this list is
+     * sufficient to "activate" the required keys for the scheduled transaction.
+     */
+    repeated Key signatories = 14;
+}

--- a/services/state/throttles/throttle_usage_snapshots.proto
+++ b/services/state/throttles/throttle_usage_snapshots.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.throttles">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+message ThrottleUsageSnapshots {
+  /**
+   * Snapshots for TPS throttles.
+   */
+  repeated ThrottleUsageSnapshot tps_throttles = 1;
+
+  /**
+   * Snapshots for gas throttle.
+   */
+  ThrottleUsageSnapshot gas_throttle = 2;
+}
+
+message ThrottleUsageSnapshot {
+  /**
+   * Used throttle capacity.
+   */
+  int64 used = 1;
+  /**
+   * The last time at which the capacity was updated.
+   */
+  Timestamp last_decision_time = 2;
+}

--- a/services/state/throttles/throttle_usage_snapshots.proto
+++ b/services/state/throttles/throttle_usage_snapshots.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "timestamp.proto";
@@ -40,6 +40,7 @@ message ThrottleUsageSnapshots {
   ThrottleUsageSnapshot gas_throttle = 2;
 }
 
+// <<<pbj.comparable = "last_decision_time,used" >>>
 message ThrottleUsageSnapshot {
   /**
    * Used throttle capacity.

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -22,6 +22,7 @@ package proto;
  * ‍
  */
 
+import "state/common.proto";
 import "basic_types.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -192,7 +193,7 @@ message Account {
      * The first key in the doubly-linked list of this contract's storage mappings;
      * It will be null if if the account is not a contract or the contract has no storage mappings.
      */
-    Int256Value first_contract_storage_key = 32;
+    bytes first_contract_storage_key = 32;
 }
 
 /**
@@ -223,29 +224,4 @@ message AccountFungibleTokenAllowance {
 message AccountCryptoAllowance {
     int64 spender_num = 1;
     int64 amount = 2;
-}
-/**
- * Message representing a uint256 value.
- */
-message Int256Value {
-    /**
-     * The number low-order bytes in the 256-bits that contain ones
-     */
-    int32 non_zero_bits = 1;
-    /**
-     * The first 64 bits of a int256 value
-     */
-    int64 first_long = 2;
-    /**
-     * The second 64 bits of a int256 value
-     */
-    int64 second_long = 3;
-    /**
-     * The first 64 bits of a int256 value
-     */
-    int64 third_long = 4;
-    /**
-     * The first 64 bits of a int256 value
-     */
-    int64 fourth_long = 5;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -23,7 +23,6 @@ package proto;
  */
 
 import "basic_types.proto";
-import "crypto_approve_allowance.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
@@ -168,7 +167,7 @@ message Account {
      * NFT token number using approved_for_all flag.
      * Allowances for a specific serial number is stored in the NFT itself in state.
      */
-    repeated AccountTokenAllowance approve_for_all_nft_allowances = 28;
+    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
@@ -189,29 +188,64 @@ message Account {
      * and the time the system task actually auto-renews it.
      */
     bool expired_and_pending_removal = 31;
+    /**
+     * The first key in the doubly-linked list of this contract's storage mappings;
+     * It will be null if if the account is not a contract or the contract has no storage mappings.
+     */
+    Int256Value first_contract_storage_key = 32;
 }
 
 /**
- * Allowance granted by this account to another account for a specific token.
+ * Allowance granted by this account to a spender for a specific non-fungible token
+ * using ApproveForAll. This allows spender to spend all serial numbers for the given
+ * non-fungible token number.
  */
-message AccountTokenAllowance {
+message AccountApprovalForAllAllowance {
     int64 token_num = 1;
-    int64 account_num = 2;
+    int64 spender_num = 2;
 }
 
 /**
  * Allowance granted by this account to another account for a specific fungible token.
  * This also contains the amount of the token that is approved for the account.
+ * This allows spender to spend the amount of tokens approved for the account.
  */
 message AccountFungibleTokenAllowance {
-    AccountTokenAllowance token_allowance_key = 1;
-    int64 amount = 2;
+    int64 token_num = 1;
+    int64 spender_num = 2;
+    int64 amount = 3;
 }
 
 /**
  * Allowance granted by this account to another account for an amount of hbars.
+ * This allows spender to spend the amount of hbars approved for the account.
  */
 message AccountCryptoAllowance {
-    int64 account_num = 1;
+    int64 spender_num = 1;
     int64 amount = 2;
+}
+/**
+ * Message representing a uint256 value.
+ */
+message Int256Value {
+    /**
+     * The number low-order bytes in the 256-bits that contain ones
+     */
+    int32 non_zero_bits = 1;
+    /**
+     * The first 64 bits of a int256 value
+     */
+    int64 first_long = 2;
+    /**
+     * The second 64 bits of a int256 value
+     */
+    int64 second_long = 3;
+    /**
+     * The first 64 bits of a int256 value
+     */
+    int64 third_long = 4;
+    /**
+     * The first 64 bits of a int256 value
+     */
+    int64 fourth_long = 5;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -78,108 +78,120 @@ message Account {
      * be set to the time when the account starts staking to a node.
      */
     int64 stake_period_start = 9;
+
     /**
-     * The node number or the account number this account is staked to.
-     * It is negative if staking to a node and positive if staking to an account and 0 if not staking to anyone.
-     * When staking to a node, it is stored as -node-1 to differentiate node 0.
+     * ID of the account or node to which this account is staking.
      */
-    int64 staked_number = 10;
+    oneof staked_id {
+
+        /**
+         * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes this account's staked account ID.
+         */
+        AccountID staked_account_id = 10;
+
+        /**
+         * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+         * removes this account's staked node ID.
+         */
+        int64 staked_node_id = 11;
+    }
     /**
      * A boolean marking if the account declines rewards.
      */
-    bool decline_reward = 11;
+    bool decline_reward = 12;
     /**
      * A boolean marking if the account requires a receiver signature.
      */
-    bool receiver_sig_required = 12;
+    bool receiver_sig_required = 13;
     /**
      * The token ID of the head of the linked list from token relations map for the account.
      */
-    int64 head_token_number = 13;
+    int64 head_token_number = 14;
     /**
      * The NftID of the head of the linked list from unique tokens map for the account.
      */
-    int64 head_nft_id = 14;
+    int64 head_nft_id = 15;
     /**
       * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
-    int64 head_nft_serial_number = 15;
+    int64 head_nft_serial_number = 16;
     /**
      * The number of NFTs owned by the account.
      */
-    int64 number_owned_nfts = 16;
+    int64 number_owned_nfts = 17;
     /**
      * The maximum number of tokens that can be auto-associated with the account.
      */
-    int32 max_auto_associations = 17;
+    int32 max_auto_associations = 18;
     /**
      * The number of used auto-association slots.
      */
-    int32 used_auto_associations = 18;
+    int32 used_auto_associations = 19;
     /**
      * The number of tokens associated with the account. This number is used for
      * fee calculation during renewal of the account.
      */
-    int32 number_associations = 19;
+    int32 number_associations = 20;
     /**
      * A boolean marking if the account is a smart contract.
      */
-    bool smart_contract = 20;
+    bool smart_contract = 21;
     /**
      * The number of tokens with a positive balance associated with the account.
      * If the account has positive balance in a token, it can not be deleted.
      */
-    int32 number_positive_balances = 21;
+    int32 number_positive_balances = 22;
     /**
      * The nonce of the account, used for Ethereum interoperability.
      */
-    int64 ethereum_nonce = 22;
+    int64 ethereum_nonce = 23;
     /**
      * The amount of hbars staked to the account at the start of the last rewarded period.
      */
-    int64 stake_at_start_of_last_rewarded_period = 23;
+    int64 stake_at_start_of_last_rewarded_period = 24;
     /**
      * (Optional) The number of an auto-renew account, in the same shard and realm as the account, that
      * has signed a transaction allowing the network to use its balance to automatically extend the account's
      * expiration time when it passes.
      */
-    int64 auto_renew_account_number = 24;
+    int64 auto_renew_account_number = 25;
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
      * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 25;
+    int64 auto_renew_secs = 26;
     /**
      * If this account is a smart-contract, number of key-value pairs stored on the contract.
      * This is used to determine the storage rent for the contract.
      */
-    int32 contract_kv_pairs_number = 26;
+    int32 contract_kv_pairs_number = 27;
     /**
      * (Optional) List of crypto allowances approved by the account.
      * It contains account number for which the allowance is approved to and
      * the amount approved for that account.
      */
-    repeated AccountCryptoAllowance crypto_allowances = 27;
+    repeated AccountCryptoAllowance crypto_allowances = 28;
     /**
      * (Optional) List of non-fungible token allowances approved for all by the account.
      * It contains account number approved for spending all serial numbers for the given
      * NFT token number using approved_for_all flag.
      * Allowances for a specific serial number is stored in the NFT itself in state.
      */
-    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 28;
+    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 29;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
      * It contains account number for which the allowance is approved to and  the token number.
      * It also contains and the amount approved for that account.
      */
-    repeated AccountFungibleTokenAllowance token_allowances = 29;
+    repeated AccountFungibleTokenAllowance token_allowances = 30;
     /**
      * The number of tokens for which this account is treasury
      */
-    uint32 number_treasury_titles = 30;
+    uint32 number_treasury_titles = 31;
     /**
      * A flag indicating if the account is expired and pending removal.
      * Only the entity expiration system task toggles this flag when it reaches this account
@@ -188,12 +200,12 @@ message Account {
      * auto-renew account from being treated as expired in the interval between its expiration
      * and the time the system task actually auto-renews it.
      */
-    bool expired_and_pending_removal = 31;
+    bool expired_and_pending_removal = 32;
     /**
      * The first key in the doubly-linked list of this contract's storage mappings;
      * It will be null if if the account is not a contract or the contract has no storage mappings.
      */
-    bytes first_contract_storage_key = 32;
+    bytes first_contract_storage_key = 33;
 }
 
 /**

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -1,0 +1,185 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "crypto_approve_allowance.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service account entity in the network Merkle tree.
+ *
+ * As with all network entities, account has an unique entity number represented as shard.realm.X.
+ * X can be an alias public key or an EVM address or a number.
+ *
+ */
+
+message Account {
+    /**
+     * The unique entity number of the account. The shard and realm numbers are implied, based on the network
+     * this entity came from.
+     */
+    int64 account_number = 1;
+    /**
+     * The alias to use for this account, if any.
+     */
+    bytes alias = 2;
+    /**
+     * (Optional) The key to be used to sign transactions from the account, if any.
+     * This key will not be set for hollow accounts until the account is finalized.
+     * This key should be set on all the accounts, except for immutable accounts (0.0.800 and 0.0.801).
+     */
+    Key key = 3;
+    /**
+     * The expiration time of the account, in seconds since the epoch.
+     */
+    int64 expiry = 4;
+    /**
+     * The balance of the account, in tiny-bars.
+     */
+    int64 tinybar_balance = 5;
+    /**
+     * An optional description of the account with UTF-8 encoding up to 100 bytes.
+     */
+    string memo = 6;
+    /**
+     * A boolean marking if the account has been deleted.
+     */
+    bool deleted = 7;
+    /**
+     * The amount of hbars staked to the account.
+     */
+    int64 staked_to_me = 8;
+    /**
+     * If this account stakes to another account, its value will be -1. It will
+     * be set to the time when the account starts staking to a node.
+     */
+    int64 stake_period_start = 9;
+    /**
+     * The node number or the account number this account is staked to.
+     * It is negative if staking to a node and positive if staking to an account and 0 if not staking to anyone.
+     * When staking to a node, it is stored as -node-1 to differentiate node 0.
+     */
+    int64 staked_number = 10;
+    /**
+     * A boolean marking if the account declines rewards.
+     */
+    bool decline_reward = 11;
+    /**
+     * A boolean marking if the account requires a receiver signature.
+     */
+    bool receiver_sig_required = 12;
+    /**
+     * The token ID of the head of the linked list from token relations map for the account.
+     */
+    int64 head_token_number = 13;
+    /**
+     * The NftId of the head of the linked list from unique tokens map for the account.
+     */
+    int64 head_nft_id = 14;
+    /**
+      * The serial number of the head NftId of the linked list from unique tokens map for the account.
+      */
+    int64 head_nft_serial_number = 15;
+    /**
+     * The number of NFTs owned by the account.
+     */
+    int64 number_owned_nfts = 16;
+    /**
+     * The maximum number of tokens that can be auto-associated with the account.
+     */
+    int32 max_auto_associations = 17;
+    /**
+     * The number of used auto-association slots.
+     */
+    int32 used_auto_associations = 18;
+    /**
+     * The number of tokens associated with the account. This number is used for
+     * fee calculation during renewal of the account.
+     */
+    int32 number_associations = 19;
+    /**
+     * A boolean marking if the account is a smart contract.
+     */
+    bool smart_contract = 20;
+    /**
+     * The number of tokens with a positive balance associated with the account.
+     * If the account has positive balance in a token, it can not be deleted.
+     */
+    int32 number_positive_balances = 21;
+    /**
+     * The nonce of the account, used for Ethereum interoperability.
+     */
+    int64 ethereum_nonce = 22;
+    /**
+     * The amount of hbars staked to the account at the start of the last rewarded period.
+     */
+    int64 stake_at_start_of_last_rewarded_period = 23;
+    /**
+     * (Optional) The number of an auto-renew account, in the same shard and realm as the account, that
+     * has signed a transaction allowing the network to use its balance to automatically extend the account's
+     * expiration time when it passes.
+     */
+    int64 auto_renew_account_number = 24;
+    /**
+     * The number of seconds the network should automatically extend the account's expiration by, if the
+     * account has a valid auto-renew account, and is not deleted upon expiration.
+     * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+     */
+    int64 auto_renew_secs = 25;
+    /**
+     * If this account is a smart-contract, number of key-value pairs stored on the contract.
+     * This is used to determine the storage rent for the contract.
+     */
+    int32 contract_kv_pairs_number = 26;
+    /**
+     * (Optional) List of crypto allowances approved by the account.
+     */
+    repeated CryptoAllowance crypto_allowances = 27;
+    /**
+     * (Optional) List of non-fungible token allowances approved by the account.
+     */
+    repeated NftAllowance nft_allowances = 28;
+
+    /**
+     * (Optional) List of fungible token allowances approved by the account.
+     */
+    repeated TokenAllowance token_allowances = 29;
+    /**
+     * The number of tokens for which this account is treasury
+     */
+    uint32 number_treasury_titles = 30;
+    /**
+     * A flag indicating if the account is expired and pending removal.
+     * Only the entity expiration system task toggles this flag when it reaches this account
+     * and finds it expired. Before setting the flag the system task checks if the account has
+     * an auto-renew account with balance. This is done to prevent a zero-balance account with a funded
+     * auto-renew account from being treated as expired in the interval between its expiration
+     * and the time the system task actually auto-renews it.
+     */
+    bool expired_and_pending_removal = 31;
+}

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -30,11 +30,10 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service account entity in the network Merkle tree.
+ * Representation of a Hedera Token Service account entity in the network Merkle tree.
  *
- * As with all network entities, account has an unique entity number represented as shard.realm.X.
+ * As with all network entities, account has a unique entity number represented as shard.realm.X.
  * X can be an alias public key or an EVM address or a number.
- *
  */
 
 message Account {
@@ -55,7 +54,7 @@ message Account {
     /**
      * The expiration time of the account, in seconds since the epoch.
      */
-    int64 expiry = 4;
+    int64 expiration_second = 4;
     /**
      * The balance of the account, in tiny-bars.
      */
@@ -82,17 +81,16 @@ message Account {
      * ID of the account or node to which this account is staking.
      */
     oneof staked_id {
-
         /**
          * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
          * this field removes this account's staked account ID.
          */
         AccountID staked_account_id = 10;
 
-    /**
-         * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
-         * removes this account's staked node ID.
-     */
+        /**
+             * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+             * removes this account's staked node ID.
+         */
         int64 staked_node_id = 11;
     }
     /**
@@ -158,10 +156,10 @@ message Account {
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
-     * If this is not provided in a allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * If this is not provided in an allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 26;
+    int64 auto_renew_seconds = 26;
     /**
      * If this account is a smart-contract, number of key-value pairs stored on the contract.
      * This is used to determine the storage rent for the contract.

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "state/common.proto";
@@ -210,6 +210,7 @@ message Account {
  * using ApproveForAll. This allows spender to spend all serial numbers for the given
  * non-fungible token id.
  */
+// <<<pbj.comparable = "token_id,spender_id" >>>
 message AccountApprovalForAllAllowance {
     TokenID token_id = 1;
     AccountID spender_id = 2;
@@ -220,6 +221,7 @@ message AccountApprovalForAllAllowance {
  * This also contains the amount of the token that is approved for the account.
  * This allows spender to spend the amount of tokens approved for the account.
  */
+// <<<pbj.comparable = "token_id,spender_id,amount" >>>
 message AccountFungibleTokenAllowance {
     TokenID token_id = 1;
     AccountID spender_id = 2;
@@ -230,6 +232,7 @@ message AccountFungibleTokenAllowance {
  * Allowance granted by this account to another account for an amount of hbars.
  * This allows spender to spend the amount of hbars approved for the account.
  */
+// <<<pbj.comparable = "spender_id,amount" >>>
 message AccountCryptoAllowance {
     AccountID spender_id = 1;
     int64 amount = 2;

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -158,17 +158,24 @@ message Account {
     int32 contract_kv_pairs_number = 26;
     /**
      * (Optional) List of crypto allowances approved by the account.
+     * It contains account number for which the allowance is approved to and
+     * the amount approved for that account.
      */
-    repeated CryptoAllowance crypto_allowances = 27;
+    repeated AccountCryptoAllowance crypto_allowances = 27;
     /**
-     * (Optional) List of non-fungible token allowances approved by the account.
+     * (Optional) List of non-fungible token allowances approved for all by the account.
+     * It contains account number approved for spending all serial numbers for the given
+     * NFT token number using approved_for_all flag.
+     * Allowances for a specific serial number is stored in the NFT itself in state.
      */
-    repeated NftAllowance nft_allowances = 28;
+    repeated AccountTokenAllowance approve_for_all_nft_allowances = 28;
 
     /**
      * (Optional) List of fungible token allowances approved by the account.
+     * It contains account number for which the allowance is approved to and  the token number.
+     * It also contains and the amount approved for that account.
      */
-    repeated TokenAllowance token_allowances = 29;
+    repeated AccountFungibleTokenAllowance token_allowances = 29;
     /**
      * The number of tokens for which this account is treasury
      */
@@ -182,4 +189,29 @@ message Account {
      * and the time the system task actually auto-renews it.
      */
     bool expired_and_pending_removal = 31;
+}
+
+/**
+ * Allowance granted by this account to another account for a specific token.
+ */
+message AccountTokenAllowance {
+    int64 token_num = 1;
+    int64 account_num = 2;
+}
+
+/**
+ * Allowance granted by this account to another account for a specific fungible token.
+ * This also contains the amount of the token that is approved for the account.
+ */
+message AccountFungibleTokenAllowance {
+    AccountTokenAllowance token_allowance_key = 1;
+    int64 amount = 2;
+}
+
+/**
+ * Allowance granted by this account to another account for an amount of hbars.
+ */
+message AccountCryptoAllowance {
+    int64 account_num = 1;
+    int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -39,10 +39,9 @@ option java_multiple_files = true;
 
 message Account {
     /**
-     * The unique entity number of the account. The shard and realm numbers are implied, based on the network
-     * this entity came from.
+     * The unique entity id of the account.
      */
-    int64 account_number = 1;
+    AccountID account_id = 1;
     /**
      * The alias to use for this account, if any.
      */
@@ -90,10 +89,10 @@ message Account {
          */
         AccountID staked_account_id = 10;
 
-        /**
+    /**
          * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
          * removes this account's staked node ID.
-         */
+     */
         int64 staked_node_id = 11;
     }
     /**
@@ -107,11 +106,11 @@ message Account {
     /**
      * The token ID of the head of the linked list from token relations map for the account.
      */
-    int64 head_token_number = 14;
+    TokenID head_token_id = 14;
     /**
      * The NftID of the head of the linked list from unique tokens map for the account.
      */
-    int64 head_nft_id = 15;
+    NftID head_nft_id = 15;
     /**
       * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
@@ -151,11 +150,11 @@ message Account {
      */
     int64 stake_at_start_of_last_rewarded_period = 24;
     /**
-     * (Optional) The number of an auto-renew account, in the same shard and realm as the account, that
+     * (Optional) The id of an auto-renew account, in the same shard and realm as the account, that
      * has signed a transaction allowing the network to use its balance to automatically extend the account's
      * expiration time when it passes.
      */
-    int64 auto_renew_account_number = 25;
+    AccountID auto_renew_account_id = 25;
     /**
      * The number of seconds the network should automatically extend the account's expiration by, if the
      * account has a valid auto-renew account, and is not deleted upon expiration.
@@ -211,11 +210,11 @@ message Account {
 /**
  * Allowance granted by this account to a spender for a specific non-fungible token
  * using ApproveForAll. This allows spender to spend all serial numbers for the given
- * non-fungible token number.
+ * non-fungible token id.
  */
 message AccountApprovalForAllAllowance {
-    int64 token_num = 1;
-    int64 spender_num = 2;
+    TokenID token_id = 1;
+    AccountID spender_id = 2;
 }
 
 /**
@@ -224,8 +223,8 @@ message AccountApprovalForAllAllowance {
  * This allows spender to spend the amount of tokens approved for the account.
  */
 message AccountFungibleTokenAllowance {
-    int64 token_num = 1;
-    int64 spender_num = 2;
+    TokenID token_id = 1;
+    AccountID spender_id = 2;
     int64 amount = 3;
 }
 
@@ -234,6 +233,6 @@ message AccountFungibleTokenAllowance {
  * This allows spender to spend the amount of hbars approved for the account.
  */
 message AccountCryptoAllowance {
-    int64 spender_num = 1;
+    AccountID spender_id = 1;
     int64 amount = 2;
 }

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -97,11 +97,11 @@ message Account {
      */
     int64 head_token_number = 13;
     /**
-     * The NftId of the head of the linked list from unique tokens map for the account.
+     * The NftID of the head of the linked list from unique tokens map for the account.
      */
     int64 head_nft_id = 14;
     /**
-      * The serial number of the head NftId of the linked list from unique tokens map for the account.
+      * The serial number of the head NftID of the linked list from unique tokens map for the account.
       */
     int64 head_nft_serial_number = 15;
     /**

--- a/services/state/token/network_staking_rewards.proto
+++ b/services/state/token/network_staking_rewards.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service staking reward entity in the network Merkle tree.
+ * This consist of all the information needed to calculate the staking rewards for all nodes in the network. It is
+ * calculated at the beginning of each staking period for all nodes and is needed to have same values
+ * for reconnect.
+ *
+ * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ */
+message NetworkStakingRewards {
+
+  /**
+   * Whether staking rewards are activated on the network. This is set to true when the balance of 0.0.800
+   * reaches minimum required balance.
+   */
+  bool staking_rewards_activated = 1;
+
+  /**
+  * Total of (balance + stakedToMe) for all accounts staked to all nodes in the network with declineReward=false, at the
+  * beginning of the new staking period.
+  */
+  int64 total_staked_reward_start = 2;
+
+  /**
+  * Total of (balance + stakedToMe) for all accounts staked to all nodes in the network, at the beginning of the new
+  * staking period.
+  */
+  int64 total_staked_start = 3;
+
+  /**
+   * The total staking rewards in tinybars that COULD be collected by all accounts staking to all nodes after the end
+   * of this staking period; assuming that no account "renounces" its rewards by, for example, setting declineReward=true.
+   */
+  int64 pending_rewards = 4;
+}

--- a/services/state/token/network_staking_rewards.proto
+++ b/services/state/token/network_staking_rewards.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -34,6 +34,7 @@ option java_multiple_files = true;
  *
  * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
  */
+// <<<pbj.comparable = "staking_rewards_activated,total_staked_reward_start,total_staked_start,pending_rewards" >>>
 message NetworkStakingRewards {
 
   /**

--- a/services/state/token/network_staking_rewards.proto
+++ b/services/state/token/network_staking_rewards.proto
@@ -27,12 +27,12 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service staking reward entity in the network Merkle tree.
- * This consist of all the information needed to calculate the staking rewards for all nodes in the network. It is
+ * Representation of a Hedera Token Service staking reward entity in the network Merkle tree.
+ * This consists of all the information needed to calculate the staking rewards for all nodes in the network. It is
  * calculated at the beginning of each staking period for all nodes and is needed to have same values
  * for reconnect.
  *
- * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
  */
 message NetworkStakingRewards {
 

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+import "state/common.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service NFT in the network Merkle tree.
+ */
+message Nft {
+
+    /**
+     * The id of this NFT.
+     */
+    UniqueTokenId id = 1;
+
+    /**
+     * The number of the account or contract that owns this NFT. 
+     *
+     * If this number is zero in state, the NFT is owned by its token type's current treasury.
+     */
+    int64 owner_number = 2;
+
+    /**
+     * The number of the account or contract approved to spend this NFT.
+     * 
+     * If this number is zero, there is no approved spender.
+     */
+    int64 spender_number = 3;
+
+    /**
+     * The consensus time of the TokenMint that created this NFT.
+     */
+    Timestamp mint_time = 4;
+
+    /**
+     * The metadata of this NFT, up to 100 bytes; usually the UTF-8 encoding of a URI.
+     */
+    bytes metadata = 5;
+
+    /**
+     * If the owner of this NFT is not its token treasury, the id of the previous NFT 
+     * in the owner's "doubly-linked list" of owned NFTs (if any).
+     */
+    UniqueTokenId owner_previous_nft_id = 6;
+
+    /**
+     * If the owner of this NFT is not its token treasury, the id of the next NFT in 
+     * the owner's "doubly-linked list" of owned NFTs (if any).
+     */
+    UniqueTokenId owner_next_nft_id = 7;
+}

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -24,7 +24,6 @@ package proto;
 
 import "timestamp.proto";
 import "basic_types.proto";
-import "state/common.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
@@ -38,8 +37,7 @@ message Nft {
     /**
      * The id of this NFT.
      */
-    UniqueTokenId id = 1;
-
+    NftID id = 1;
 
     /**
      * The account or contract id that owns this NFT.
@@ -69,11 +67,11 @@ message Nft {
      * If the owner of this NFT is not its token treasury, the id of the previous NFT 
      * in the owner's "doubly-linked list" of owned NFTs (if any).
      */
-    UniqueTokenId owner_previous_nft_id = 6;
+    NftID owner_previous_nft_id = 6;
 
     /**
      * If the owner of this NFT is not its token treasury, the id of the next NFT in 
      * the owner's "doubly-linked list" of owned NFTs (if any).
      */
-    UniqueTokenId owner_next_nft_id = 7;
+    NftID owner_next_nft_id = 7;
 }

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "timestamp.proto";
@@ -32,6 +32,7 @@ option java_multiple_files = true;
 /**
  * Representation of a Hedera Token Service NFT in the network Merkle tree.
  */
+// <<<pbj.comparable = "owner_id,nft_id,spender_id,mint_time,owner_previous_nft_id,owner_next_nft_id,metadata" >>>
 message Nft {
 
     /**
@@ -64,13 +65,13 @@ message Nft {
     bytes metadata = 5;
 
     /**
-     * If the owner of this NFT is not its token treasury, the id of the previous NFT 
+     * If the owner of this NFT is not its token treasury, the id of the previous NFT
      * in the owner's "doubly-linked list" of owned NFTs (if any).
      */
     NftID owner_previous_nft_id = 6;
 
     /**
-     * If the owner of this NFT is not its token treasury, the id of the next NFT in 
+     * If the owner of this NFT is not its token treasury, the id of the next NFT in
      * the owner's "doubly-linked list" of owned NFTs (if any).
      */
     NftID owner_next_nft_id = 7;

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -23,6 +23,7 @@ package proto;
  */
 
 import "timestamp.proto";
+import "basic_types.proto";
 import "state/common.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -39,19 +40,20 @@ message Nft {
      */
     UniqueTokenId id = 1;
 
+
     /**
-     * The number of the account or contract that owns this NFT. 
+     * The account or contract id that owns this NFT.
      *
      * If this number is zero in state, the NFT is owned by its token type's current treasury.
      */
-    int64 owner_number = 2;
+    AccountID owner_id = 2;
 
     /**
-     * The number of the account or contract approved to spend this NFT.
-     * 
+     * The account or contract id approved to spend this NFT.
+     *
      * If this number is zero, there is no approved spender.
      */
-    int64 spender_number = 3;
+    AccountID spender_id = 3;
 
     /**
      * The consensus time of the TokenMint that created this NFT.

--- a/services/state/token/nft.proto
+++ b/services/state/token/nft.proto
@@ -30,14 +30,14 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service NFT in the network Merkle tree.
+ * Representation of a Hedera Token Service NFT in the network Merkle tree.
  */
 message Nft {
 
     /**
      * The id of this NFT.
      */
-    NftID id = 1;
+    NftID nft_id = 1;
 
     /**
      * The account or contract id that owns this NFT.

--- a/services/state/token/staking_node_info.proto
+++ b/services/state/token/staking_node_info.proto
@@ -88,4 +88,15 @@ message StakingNodeInfo {
      * (node A stake * 500/ total stake of all nodes)
      */
     int32 weight = 10;
+    /**
+     * The total staking rewards in tinybars that COULD be collected by all accounts staking to the current node after the end
+     * of this staking period; assuming that no account "renounces" its rewards by, for example, setting declineReward=true.
+     * When the current node is deleted, this amount will be subtracted from the total pending rewards of all accounts staking
+     * to all nodes in the network in NetworkStakingRewards.
+     */
+    int64 pending_rewards = 11;
+    /**
+     * True if this node has been deleted from network.
+     */
+    bool deleted = 12;
 }

--- a/services/state/token/staking_node_info.proto
+++ b/services/state/token/staking_node_info.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "state/common.proto";
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service staking info entity in the network Merkle tree.
+ *
+ * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ */
+message StakingNodeInfo {
+    /**
+     * The unique entity number of the node. The shard and realm numbers are implied, based on the network
+     * this entity came from.
+     */
+    int64 node_number = 1;
+    /**
+     * The minimum stake on this node that is required for this node to have a non-zero weight to
+     * participate in the network consensus.
+     */
+    int64 min_stake = 2;
+    /**
+     * The maximum stake on this node that is considered to calculate its weight to participate in the network consensus.
+     */
+    int64 max_stake = 3;
+    /**
+     * The sum of balances of all accounts staked to this node who have opted to receive rewards.
+     */
+    int64 stake_to_reward = 4;
+    /**
+     * The sum of balances of all accounts staked to this node who have opted to decline rewards.
+     */
+    int64 stake_to_not_reward = 5;
+    /**
+     * The snapshot of stake_to_reward value at the beginning of the current staking period.
+     * This is needed for calculating rewards for current staking period without considering changes to
+     * stake_to_reward in the current staking period. It is reset at the beginning of every period.
+     */
+    int64 stake_reward_start = 6;
+    /**
+     * Tracks how much stake from stakeRewardStart will have unclaimed rewards due to accounts changing their staking
+     * metadata in a way that disqualifies them for the current period; It is reset at the beginning of every period
+     */
+    int64 unclaimed_stake_reward_start = 7;
+    /**
+     * The total amount of effective hbar staked to this node. This is sum of stake_to_reward and stake_to_not_reward.
+     * If the sum is greater than max_stake, then the effective stake is max_stake.
+     * If the sum is less than min_stake, then the effective stake is 0.
+     */
+    int64 stake = 8;
+    /**
+     * An running sum of reward rates per hbar for the last 365+1 staking periods. The first element is the
+     * is the reward up to and including the last full period that finished before the present. Second element is
+     * the reward up to and including the period before that
+     */
+    repeated int64 reward_sum_history = 9;
+    /**
+     * The consensus weight of this node in the network. This is computed based on the stake of this node
+     * at midnight UTC of the current day. If the stake of this node is less than minStake, then the weight is 0.
+     * Sum of all weights of nodes in the network should be less than 500.
+     * If the stake of this node A is greater than minStake, then the weight of this node A is calculated as:
+     * (node A stake * 500/ total stake of all nodes)
+     */
+    int32 weight = 10;
+}

--- a/services/state/token/staking_node_info.proto
+++ b/services/state/token/staking_node_info.proto
@@ -30,9 +30,9 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service staking info entity in the network Merkle tree.
+ * Representation of a Hedera Token Service staking info entity in the network Merkle tree.
  *
- * As with all network entities, staking info is per node and has an unique entity number represented as shard.realm.X.
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
  */
 message StakingNodeInfo {
     /**

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -161,4 +161,15 @@ message Token {
      * (Optional) The custom fees of this token.
      */
     repeated CustomFee custom_fees = 26;
+
+    /**
+     * Metadata of the created token definition
+     */
+    bytes metadata = 27;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition and individual NFTs).
+     */
+    Key metadata_key = 28;
 }

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -1,0 +1,164 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "custom_fees.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * First-draft representation of a Hedera Token Service token entity in the network Merkle tree.
+ *
+ * As with all network entities, a token has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+
+message Token {
+    /**
+     * The unique entity number of this token.
+     */
+    int64 token_number = 1;
+    /**
+     * The human-readable name of this token and its not necessarily unique. Maximum length allowed is 100 bytes.
+     */
+    string name = 2;
+    /**
+     * The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+     */
+    string symbol = 3;
+    /**
+     * The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+     * tokens can be at most a few billions or millions, respectively. For example, it could match
+     * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+     * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+     */
+    int32 decimals = 4;
+    /**
+     * The total supply of this token.
+     */
+    int64 total_supply = 5;
+    /**
+     * The treasury account number of this token. This account receives the initial supply of
+     * tokens as-well as the tokens from the Token Mint operation once executed. The balance
+     * of the treasury account is decreased when the Token Burn operation is executed.
+     */
+    int64 treasury_account_number = 6;
+    /**
+     * (Optional) The admin key of this token. If this key is set, the token is mutable.
+     * A mutable token can be modified.
+     * If this key is not set on token creation, it cannot be modified.
+     */
+    Key admin_key = 7;
+    /**
+     * (Optional) The kyc key of this token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key kyc_key = 8;
+    /**
+     * (Optional) The freeze key of this token. This key is needed for freezing the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key freeze_key = 9;
+    /**
+     * (Optional) The wipe key of this token. This key is needed for wiping the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key wipe_key = 10;
+    /**
+     * (Optional) The supply key of this token. This key is needed for minting or burning token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key supply_key = 11;
+    /**
+     * (Optional) The fee schedule key of this token. This key should be set, in order to make any
+     * changes to the custom fee schedule.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key fee_schedule_key = 12;
+    /**
+     * (Optional) The pause key of this token. This key is needed for pausing the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key pause_key = 13;
+    /**
+     * The last used serial number of this token.
+     */
+    int64 last_used_serial_number = 14;
+    /**
+     * The flag indicating if this token is deleted.
+     */
+    bool deleted = 15;
+    /**
+     * The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+     * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+     */
+    TokenType token_type = 16;
+    /**
+     * The supply type of this token.A token can have either INFINITE or FINITE supply type.
+     * If it has been omitted during token creation, INFINITE type is used.
+     */
+    TokenSupplyType supply_type = 17;
+    /**
+     * The number of the account (if any) that the network will attempt to charge for the
+     * token's auto-renewal upon expiration.
+     */
+    int64 auto_renew_account_number = 18;
+    /**
+     * The number of seconds the network should automatically extend the token's expiration by, if the
+     * token has a valid auto-renew account, and is not deleted upon expiration.
+     * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+     */
+    int64 auto_renew_secs = 19;
+    /**
+     * The expiration time of the token, in seconds since the epoch.
+     */
+    int64 expiry = 20;
+    /**
+     * An optional description of the token with UTF-8 encoding up to 100 bytes.
+     */
+    string memo = 21;
+    /**
+     * The maximum supply of this token.
+     */
+    int64 max_supply = 22;
+    /**
+     * The flag indicating if this token is paused.
+     */
+    bool paused = 23;
+    /**
+     * The flag indicating if this token has accounts associated to it that are frozen by default.
+     */
+    bool accounts_frozen_by_default = 24;
+    /**
+      * The flag indicating if this token has accounts associated to it that are KYC granted by default.
+     */
+    bool accounts_kyc_granted_by_default = 25;
+    /**
+     * (Optional) The custom fees of this token.
+     */
+    repeated CustomFee custom_fees = 26;
+}

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -30,7 +30,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * First-draft representation of a Hedera Token Service token entity in the network Merkle tree.
+ * Representation of a Hedera Token Service token entity in the network Merkle tree.
  *
  * As with all network entities, a token has a unique entity number, which is usually given along
  * with the network's shard and realm in the form of a shard.realm.number id.
@@ -42,7 +42,7 @@ message Token {
      */
     TokenID token_id = 1;
     /**
-     * The human-readable name of this token and its not necessarily unique. Maximum length allowed is 100 bytes.
+     * The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
      */
     string name = 2;
     /**
@@ -62,7 +62,7 @@ message Token {
     int64 total_supply = 5;
     /**
      * The treasury account id of this token. This account receives the initial supply of
-     * tokens as-well as the tokens from the Token Mint operation once executed. The balance
+     * tokens as well as the tokens from the Token Mint operation once executed. The balance
      * of the treasury account is decreased when the Token Burn operation is executed.
      */
     AccountID treasury_account_id = 6;
@@ -132,11 +132,11 @@ message Token {
      * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
      * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
      */
-    int64 auto_renew_secs = 19;
+    int64 auto_renew_seconds = 19;
     /**
      * The expiration time of the token, in seconds since the epoch.
      */
-    int64 expiry = 20;
+    int64 expiration_second = 20;
     /**
      * An optional description of the token with UTF-8 encoding up to 100 bytes.
      */
@@ -154,7 +154,7 @@ message Token {
      */
     bool accounts_frozen_by_default = 24;
     /**
-      * The flag indicating if this token has accounts associated to it that are KYC granted by default.
+      * The flag indicating if this token has accounts associated with it that are KYC granted by default.
      */
     bool accounts_kyc_granted_by_default = 25;
     /**

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -38,9 +38,9 @@ option java_multiple_files = true;
 
 message Token {
     /**
-     * The unique entity number of this token.
+     * The unique entity id of this token.
      */
-    int64 token_number = 1;
+    TokenID token_id = 1;
     /**
      * The human-readable name of this token and its not necessarily unique. Maximum length allowed is 100 bytes.
      */
@@ -61,11 +61,11 @@ message Token {
      */
     int64 total_supply = 5;
     /**
-     * The treasury account number of this token. This account receives the initial supply of
+     * The treasury account id of this token. This account receives the initial supply of
      * tokens as-well as the tokens from the Token Mint operation once executed. The balance
      * of the treasury account is decreased when the Token Burn operation is executed.
      */
-    int64 treasury_account_number = 6;
+    AccountID treasury_account_id = 6;
     /**
      * (Optional) The admin key of this token. If this key is set, the token is mutable.
      * A mutable token can be modified.
@@ -122,10 +122,10 @@ message Token {
      */
     TokenSupplyType supply_type = 17;
     /**
-     * The number of the account (if any) that the network will attempt to charge for the
+     * The id of the account (if any) that the network will attempt to charge for the
      * token's auto-renewal upon expiration.
      */
-    int64 auto_renew_account_number = 18;
+    AccountID auto_renew_account_id = 18;
     /**
      * The number of seconds the network should automatically extend the token's expiration by, if the
      * token has a valid auto-renew account, and is not deleted upon expiration.

--- a/services/state/token/token.proto
+++ b/services/state/token/token.proto
@@ -161,15 +161,4 @@ message Token {
      * (Optional) The custom fees of this token.
      */
     repeated CustomFee custom_fees = 26;
-
-    /**
-     * Metadata of the created token definition
-     */
-    bytes metadata = 27;
-
-    /**
-     * The key which can change the metadata of a token
-     * (token definition and individual NFTs).
-     */
-    Key metadata_key = 28;
 }

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+/**
+ * First-draft representation of a Hedera Token Service token relationship entity in the network Merkle tree.
+ *
+ * As with all network entities, a token relationship has a unique entity number pair, which is represented
+ * with the account and the token involved in the relationship.
+ */
+message TokenRelation {
+    /**
+     * The token involved in this relation.It takes only positive
+     */
+    int64 token_number = 1;
+    /**
+     * The account involved in this association.
+     */
+    int64 account_number = 2;
+    /**
+     * The balance of the token relationship.
+     */
+    int64 balance = 3;
+    /**
+     * The flags specifying the token relationship is frozen or not.
+     */
+    bool frozen = 4;
+    /**
+     * The flag indicating if the token relationship has been granted KYC.
+     */
+    bool kyc_granted = 5;
+    /**
+     * The flag indicating if the token relationship was deleted.
+     */
+    bool deleted = 6;
+    /**
+     * The flag indicating if the token relationship was created using automatic association.
+     */
+    bool automatic_association = 7;
+    /**
+     * The previous token number of account's association linked list
+     */
+    int64 previous_token = 8;
+    /**
+     * The next token number of account's association linked list
+     */
+    int64 next_token = 9;
+}

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -28,7 +28,7 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 /**
- * First-draft representation of a Hedera Token Service token relationship entity in the network Merkle tree.
+ * Representation of a Hedera Token Service token relationship entity in the network Merkle tree.
  *
  * As with all network entities, a token relationship has a unique entity number pair, which is represented
  * with the account and the token involved in the relationship.

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -37,11 +37,11 @@ message TokenRelation {
     /**
      * The token involved in this relation.It takes only positive
      */
-    int64 token_number = 1;
+    TokenID token_id = 1;
     /**
      * The account involved in this association.
      */
-    int64 account_number = 2;
+    AccountID account_id = 2;
     /**
      * The balance of the token relationship.
      */
@@ -63,11 +63,11 @@ message TokenRelation {
      */
     bool automatic_association = 7;
     /**
-     * The previous token number of account's association linked list
+     * The previous token id of account's association linked list
      */
-    int64 previous_token = 8;
+    TokenID previous_token = 8;
     /**
-     * The next token number of account's association linked list
+     * The next token id of account's association linked list
      */
-    int64 next_token = 9;
+    TokenID next_token = 9;
 }

--- a/services/state/token/token_relation.proto
+++ b/services/state/token/token_relation.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 import "basic_types.proto";
@@ -33,6 +33,7 @@ option java_multiple_files = true;
  * As with all network entities, a token relationship has a unique entity number pair, which is represented
  * with the account and the token involved in the relationship.
  */
+// <<<pbj.comparable = "token_id,account_id,deleted,frozen,kyc_granted,automatic_association,previous_token,next_token,balance" >>>
 message TokenRelation {
     /**
      * The token involved in this relation.It takes only positive

--- a/services/timestamp.proto
+++ b/services/timestamp.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package proto;
 
 /*-
- * ‌
+ *
  * Hedera Network Services Protobuf
- * ​
+ *
  * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
- * ​
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +19,7 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
+ *
  */
 
 option java_package = "com.hederahashgraph.api.proto.java";
@@ -30,6 +30,7 @@ option java_multiple_files = true;
  * An exact date and time. This is the same data structure as the protobuf Timestamp.proto (see the
  * comments in https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto)
  */
+// <<<pbj.comparable = "seconds,nanos" >>>
 message Timestamp {
     /**
      * Number of complete seconds since the start of the epoch
@@ -45,10 +46,10 @@ message Timestamp {
 /**
  * An exact date and time,  with a resolution of one second (no nanoseconds).
  */
+// <<<pbj.comparable = "seconds" >>>
 message TimestampSeconds {
     /**
      * Number of complete seconds since the start of the epoch
      */
     int64 seconds = 1;
 }
-

--- a/services/token_create.proto
+++ b/services/token_create.proto
@@ -200,8 +200,8 @@ message TokenCreateTransactionBody {
     Key pause_key = 22;
 
     /**
-   * Metadata of the created token definition.
-   */
+     * Metadata of the created token definition.
+     */
     bytes metadata = 23;
 
     /**

--- a/services/token_create.proto
+++ b/services/token_create.proto
@@ -198,4 +198,15 @@ message TokenCreateTransactionBody {
      * If Empty the token pause status defaults to PauseNotApplicable, otherwise Unpaused.
      */
     Key pause_key = 22;
+
+    /**
+   * Metadata of the created token definition.
+   */
+    bytes metadata = 23;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 24;
 }

--- a/services/token_create.proto
+++ b/services/token_create.proto
@@ -200,8 +200,8 @@ message TokenCreateTransactionBody {
     Key pause_key = 22;
 
     /**
-     * Metadata of the created token definition.
-     */
+   * Metadata of the created token definition.
+   */
     bytes metadata = 23;
 
     /**

--- a/services/token_get_info.proto
+++ b/services/token_get_info.proto
@@ -198,6 +198,17 @@ message TokenInfo {
      * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
      */
     bytes ledger_id = 26;
+
+    /**
+     * Represents the metadata of the token definition.
+     */
+    bytes metadata = 27;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 28;
 }
 
 /**

--- a/services/token_get_info.proto
+++ b/services/token_get_info.proto
@@ -198,17 +198,6 @@ message TokenInfo {
      * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
      */
     bytes ledger_id = 26;
-
-    /**
-     * Represents the metadata of the token definition.
-     */
-    bytes metadata = 27;
-
-    /**
-     * The key which can change the metadata of a token
-     * (token definition, partition definition, and individual NFTs).
-     */
-    Key metadata_key = 28;
 }
 
 /**

--- a/services/token_get_nft_info.proto
+++ b/services/token_get_nft_info.proto
@@ -32,21 +32,6 @@ import "response_header.proto";
 import "timestamp.proto";
 
 /**
- * Represents an NFT on the Ledger
- */
-message NftID {
-    /**
-     * The (non-fungible) token of which this NFT is an instance
-     */
-    TokenID tokenID = 1;
-
-    /**
-     * The unique identifier of this instance
-     */
-    int64 serialNumber = 2;
-}
-
-/**
  * Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on a NFT for a given TokenID (of
  * type NON_FUNGIBLE_UNIQUE) and serial number
  */

--- a/services/token_service.proto
+++ b/services/token_service.proto
@@ -128,4 +128,7 @@ service TokenService {
 
     //  Unpause the token
     rpc unpauseToken (Transaction) returns (TransactionResponse);
+
+    // Update an NFT
+    rpc updateNft (Transaction) returns (TransactionResponse);
 }

--- a/services/token_service.proto
+++ b/services/token_service.proto
@@ -128,7 +128,4 @@ service TokenService {
 
     //  Unpause the token
     rpc unpauseToken (Transaction) returns (TransactionResponse);
-
-    // Update an NFT
-    rpc updateNft (Transaction) returns (TransactionResponse);
 }

--- a/services/token_update.proto
+++ b/services/token_update.proto
@@ -142,4 +142,15 @@ message TokenUpdateTransactionBody {
      * transaction will resolve to TOKEN_HAS_NO_PAUSE_KEY
      */
     Key pause_key = 15;
+
+    /**
+     * Metadata of the created token definition
+     */
+    google.protobuf.BytesValue metadata = 16;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 17;
 }

--- a/services/token_update_nft.proto
+++ b/services/token_update_nft.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2024 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * At consensus, updates an already created Non Fungible Token to the given values.
+ * 
+ * If no value is given for a field, that field is left unchanged. For an immutable tokens (that is,
+ * a token without an admin key), only the expiry may be updated. Setting any other field in that
+ * case will cause the transaction status to resolve to TOKEN_IS_IMMUTABLE.
+ *
+ */
+message TokenUpdateNftTransactionBody {
+    /**
+     * The NftID of the NFT
+     */
+    NftID nft_id = 1;
+
+    /**
+     * The new metadata of the NFT
+     */
+    google.protobuf.BytesValue metadata = 2;
+}

--- a/services/transaction.proto
+++ b/services/transaction.proto
@@ -26,8 +26,6 @@ option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
-
-import "duration.proto";
 import "basic_types.proto";
 import "transaction_body.proto";
 

--- a/services/transaction.proto
+++ b/services/transaction.proto
@@ -42,7 +42,7 @@ import "transaction_body.proto";
  */
 message Transaction {
     /**
-     * the body of the transaction, which needs to be signed
+     * The body of the transaction, which needs to be signed
      */
     TransactionBody body = 1 [deprecated = true];
 


### PR DESCRIPTION
* Added the PBJ comparable comment to all non-enum basic types that do not have repeated fields
   * Repeated fields are not currently supported, and enum types are `Comparable` by default
   * Also removed a lot of random non-semantic trailing spaces
* Moved TokenID definition earlier in the file to work around an order-dependency issue in PBJ compiler.
   * This stll fails, but only in the CI environment.  Objects _in basic_types_ that use TokenID are not comparable for now.
* Added the PBJ comparable comment to timestamp, duration, and custom_fees
* Added the PBJ comparable comment to state objects where possible
   * Anything with a Key type field cannot be `Comparable` due to KeyList having a repeated field
   * Anything with a repeated field cannot be `Comparable` currently.
