### PR TITLE
HIP 796: Update TokenLock, TokenUnlock TransactionBody Definitions

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -115,8 +115,6 @@ message AccountID {
 
 message LockableSerialNumbers {
     repeated int64 serial_numbers = 1;
-    // Work around a PBJ bug for now
-    bool tbd = 2;
 }
 
 /**

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -113,10 +113,6 @@ message AccountID {
     }
 }
 
-message LockableSerialNumbers {
-    repeated int64 serial_numbers = 1;
-}
-
 /**
  * Identifier for a unique token (or "NFT"), used by both contract and token services.
  */

--- a/services/token_lock.proto
+++ b/services/token_lock.proto
@@ -34,9 +34,7 @@ import "basic_types.proto";
  */
  message TokenLockTransactionBody {
     AccountID account_id = 1;
-    TokenID token_id = 2; // token-definition-id or partition-definition-id
-    oneof amountOrSerialNumbers {
-        int64 amount = 3; // if token-definition is FUNGIBLE_COMMON
-        LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
-    }
+    TokenID token_id = 2;       // token-definition-id or partition-definition-id
+    int64 amount = 3;           // if token-definition is FUNGIBLE_COMMON
+    LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
 }

--- a/services/token_lock.proto
+++ b/services/token_lock.proto
@@ -33,8 +33,27 @@ import "basic_types.proto";
  * FUNGIBLE_COMMON token type, or a partition of such a token type.
  */
  message TokenLockTransactionBody {
-    AccountID account_id = 1;
-    TokenID token_id = 2;       // token-definition-id or partition-definition-id
-    int64 amount = 3;           // if token-definition is FUNGIBLE_COMMON
-    LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
+    /**
+     * The account in which to lock tokens.
+     */
+    AccountID account = 1;
+
+    /**
+     * The token-definition-id or partition-definition-id for which to lock tokens.
+     * If token does not exist, transaction results in INVALID_TOKEN_ID
+     */
+    TokenID token = 2;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON.
+     * The amount to lock in the specified Account.
+     * Amount must be a positive non-zero number.
+     */
+    int64 amount = 3;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE.
+     * The list of serial numbers to be locked.
+     */
+    repeated int64 serialNumbers = 4;   // if the token-definition is NON_FUNGIBLE_UNIQUE
 }

--- a/services/token_unlock.proto
+++ b/services/token_unlock.proto
@@ -34,9 +34,7 @@ import "basic_types.proto";
  */
  message TokenUnlockTransactionBody {
     AccountID account_id = 1;
-    TokenID token_id = 2; // token-definition-id or partition-definition-id
-    oneof amountOrSerialNumbers {
-        int64 amount = 3; // if token-definition is FUNGIBLE_COMMON
-        LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
-    }
+    TokenID token_id = 2;     // token-definition-id or partition-definition-id
+    int64 amount = 3;         // if token-definition is FUNGIBLE_COMMON
+    LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
 }

--- a/services/token_unlock.proto
+++ b/services/token_unlock.proto
@@ -33,8 +33,28 @@ import "basic_types.proto";
  * FUNGIBLE_COMMON token type, or a partition of such a token type.
  */
  message TokenUnlockTransactionBody {
-    AccountID account_id = 1;
-    TokenID token_id = 2;     // token-definition-id or partition-definition-id
-    int64 amount = 3;         // if token-definition is FUNGIBLE_COMMON
-    LockableSerialNumbers serial_numbers = 4; // if the token-definition is NON_FUNGIBLE_UNIQUE
+
+    /**
+     * The account in which to unlock tokens.
+     */
+    AccountID account = 1;
+
+    /**
+     * The token-definition-id or partition-definition-id for which to unlock tokens.
+     * If token does not exist, transaction results in INVALID_TOKEN_ID
+     */
+    TokenID token = 2;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON.
+     * The amount to unlock in the specified Account.
+     * Amount must be a positive non-zero number.
+     */
+    int64 amount = 3;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE.
+     * The list of serial numbers to be unlocked.
+     */
+    repeated int64 serialNumbers = 4;   // if the token-definition is NON_FUNGIBLE_UNIQUE
 }


### PR DESCRIPTION
**Description**:

Change the definitions of TokenLockTransactionBody and TokenUnlockTransactionBody
to allow multiple NFTs to be locked/unlocked with a single call

The format of the new transactions is more aligned with the rest of Token Service.

**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/9636

