### PR TITLE
HIP-540: add should_verify_key enum field to TokenUpdateTransactionBody

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -488,6 +488,21 @@ enum TokenSupplyType {
 }
 
 /**
+ * Types of validation strategies for token keys.
+ */
+enum TokenKeyValidation {
+    /**
+     * Currently the default behaviour. It will perform all token key validations.
+     */
+    FULL_VALIDATION = 0;
+
+    /**
+     * Perform no validations at all for all passed token keys.
+     */
+    NO_VALIDATION = 1;
+}
+
+/**
  * Possible Freeze statuses returned on TokenGetInfoQuery or CryptoGetInfoResponse in
  * TokenRelationship
  */

--- a/services/token_update.proto
+++ b/services/token_update.proto
@@ -155,4 +155,9 @@ message TokenUpdateTransactionBody {
      * transaction will resolve to TOKEN_HAS_NO_METADATA_KEY
      */
     Key metadata_key = 17;
+
+    /**
+     * Determines whether the system should check the validity of the passed keys for update.
+     */
+    TokenKeyValidation should_verify_key = 18;
 }


### PR DESCRIPTION
**Description**:
Add `shouldVerifyKey` enum field to `TokenUpdateTransactionBody`, initially with two values which will indicate whether or not to verify keys and keep the possibility to extend it in the future if we want to change the behaviour

**Related issue(s)**:

Fixes #332 

**Notes for reviewer**:
Adding the following enum will 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
