### PR TITLE
Reserve removed fields to preserve SDK compatibility

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -111,6 +111,10 @@ message AccountID {
          */
         bytes alias = 4;
     }
+
+    // Removed evm_address February 2023 to compress HIP 583/631
+    //     into the single immutable alias field.
+    reserved 5;
 }
 
 /**

--- a/services/crypto_create.proto
+++ b/services/crypto_create.proto
@@ -46,7 +46,7 @@ import "duration.proto";
  * used to extend its expiration as long as possible. If it is has a zero balance when it expires,
  * then it is deleted. This transaction must be signed by the payer account. If receiverSigRequired
  * is false, then the transaction does not have to be signed by the keys in the keys field. If it is
- * true, then it must be signed by them, in addition to the keys of the payer account. If the 
+ * true, then it must be signed by them, in addition to the keys of the payer account. If the
  * auto_renew_account field is set, the key of the referenced account must sign.
  *
  * An entity (account, file, or smart contract instance) must be created in a particular realm. If
@@ -62,6 +62,13 @@ import "duration.proto";
  * multiple shards.
  */
 message CryptoCreateTransactionBody {
+    // Removed auto_renew_account_id "temporarily" in January 2023.
+    // Removed evm_address February 2023 to compress HIP 583/631
+    //     into the single immutable alias field.
+    reserved 19,20;
+    // Removed prior to oldest available history
+    reserved 4,5;
+
     /**
      * The key that must sign each transfer out of the account. If receiverSigRequired is true, then
      * it must also sign any transfer into the account.
@@ -169,7 +176,7 @@ message CryptoCreateTransactionBody {
      * A given alias can map to at most one account on the network at a time. This uniqueness will be enforced
      * relative to aliases currently on the network at alias assignment.
      *
-     * If a transaction creates an account using an alias, any further crypto transfers to that alias will 
+     * If a transaction creates an account using an alias, any further crypto transfers to that alias will
      * simply be deposited in that account, without creating anything, and with no creation fee being charged.
      */
      bytes alias = 18;

--- a/services/crypto_get_info.proto
+++ b/services/crypto_get_info.proto
@@ -61,6 +61,13 @@ message CryptoGetInfoResponse {
     ResponseHeader header = 1;
 
     message AccountInfo {
+        // Removed auto_renew_account_id "temporarily" in January 2023.
+        // Removed virtual_addresses February 2023 to compress HIP 583/631
+        //     into the single immutable alias field.
+        reserved 23,24;
+        // Removed prior to oldest available history
+        reserved 5;
+
         /**
          * The account ID for which this information applies
          */
@@ -139,9 +146,9 @@ message CryptoGetInfoResponse {
         repeated LiveHash liveHashes = 14;
 
         /**
-         * [DEPRECATED] The metadata of the tokens associated to the account. This field was 
-         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
-         * an account to be associated to an unlimited number of tokens. This scale makes it more 
+         * [DEPRECATED] The metadata of the tokens associated to the account. This field was
+         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed
+         * an account to be associated to an unlimited number of tokens. This scale makes it more
          * efficient for users to consult mirror nodes to review their token associations.
          */
         repeated TokenRelationship tokenRelationships = 15 [deprecated = true];
@@ -167,7 +174,7 @@ message CryptoGetInfoResponse {
         bytes alias = 19;
 
         /**
-         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
          */
         bytes ledger_id = 20;
 

--- a/services/crypto_update.proto
+++ b/services/crypto_update.proto
@@ -36,11 +36,16 @@ import "google/protobuf/wrappers.proto";
  * transaction must be signed by the existing key for this account. If the transaction is changing
  * the key field, then the transaction must be signed by both the old key (from before the change)
  * and the new key. The old key must sign for security. The new key must sign as a safeguard to
- * avoid accidentally changing to an invalid key, and then having no way to recover. 
- * If the update transaction sets the <tt>auto_renew_account</tt> field to anything other 
+ * avoid accidentally changing to an invalid key, and then having no way to recover.
+ * If the update transaction sets the <tt>auto_renew_account</tt> field to anything other
  * than the sentinel <tt>0.0.0</tt>, the key of the referenced account must sign.
  */
 message CryptoUpdateTransactionBody {
+    // Removed auto_renew_account_id "temporarily" January 2023.
+    // Removed virtual_address_update (20,21) February 2023 to compress
+    //     HIP 583/631 into the single immutable alias field.
+    reserved 19,20,21;
+
     /**
      * The account ID which is being updated in this transaction
      */

--- a/services/file_create.proto
+++ b/services/file_create.proto
@@ -38,14 +38,14 @@ import "timestamp.proto";
  * at the expirationTime, unless its expiration is extended by another transaction before that time.
  * If the file is deleted, then its contents will become empty and it will be marked as deleted
  * until it expires, and then it will cease to exist.
- * 
+ *
  * The keys field is a list of keys. All keys within the top-level key list must sign (M-M) to
  * create or modify a file. However, to delete the file, only one key (1-M) is required to sign from
  * the top-level key list.  Each of those "keys" may itself be threshold key containing other keys
  * (including other threshold keys). In other words, the behavior is an AND for create/modify, OR
  * for delete. This is useful for acting as a revocation server. If it is desired to have the
  * behavior be AND for all 3 operations (or OR for all 3), then the list should have only a single
- * Key, which is a threshold key, with N=1 for OR, N=M for AND. If the auto_renew_account field 
+ * Key, which is a threshold key, with N=1 for OR, N=M for AND. If the auto_renew_account field
  * is set, the key of the referenced account must sign.
  *
  * If a file is created without ANY keys in the keys field, the file is immutable and ONLY the
@@ -65,6 +65,10 @@ import "timestamp.proto";
  * multiple shards.
  */
 message FileCreateTransactionBody {
+    // Removed auto_renew_account_id and auto_renew_period
+    // "temporarily" in January 2023.
+    reserved 9,10;
+
     /**
      * The time at which this file should expire (unless FileUpdateTransaction is used before then
      * to extend its life)

--- a/services/file_get_info.proto
+++ b/services/file_get_info.proto
@@ -63,6 +63,10 @@ message FileGetInfoResponse {
 
 
     message FileInfo {
+        // Removed auto_renew_account_id and auto_renew_period
+        // "temporarily" in January 2023.
+        reserved 8,9;
+
         /**
          * The file ID of the file for which information is requested
          */
@@ -94,7 +98,7 @@ message FileGetInfoResponse {
         string memo = 6;
 
         /**
-         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
          */
         bytes ledger_id = 7;
     }

--- a/services/file_update.proto
+++ b/services/file_update.proto
@@ -36,10 +36,14 @@ import "google/protobuf/wrappers.proto";
  * in the top level of a key list (M-of-M) of the file being updated. If the keys themselves are
  * being updated, then the transaction must also be signed by all the new keys. If the keys contain
  * additional KeyList or ThresholdKey then M-of-M secondary KeyList or ThresholdKey signing
- * requirements must be meet If the update transaction sets the <tt>auto_renew_account_id</tt> field 
+ * requirements must be meet If the update transaction sets the <tt>auto_renew_account_id</tt> field
  * to anything other than the sentinel <tt>0.0.0</tt>, the key of the referenced account must sign.
  */
 message FileUpdateTransactionBody {
+    // Removed auto_renew_account_id and auto_renew_period
+    // "temporarily" in January 2023.
+    reserved 6,7;
+
     /**
      * The ID of the file to update
      */


### PR DESCRIPTION
Several fields were removed from protobuf without reserving the field numbers.
Some of these removals are temporary, others are permanent.
Here we reserve the field numbers for those removed fields to ensure the field numbers are not accidentally reused, breaking compatibility.
