### PR TITLE
chore: Block Stream protobuf changes for PBJ compiler

### DIFF
--- a/block/block_service.proto
+++ b/block/block_service.proto
@@ -62,7 +62,7 @@ package com.hedera.hapi.block;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -206,7 +206,7 @@ message PublishStreamResponse {
          * This code indicates the reason the stream ended.<br/>
          * This value MUST be set to a non-default value.
          */
-        ResponseCode status = 1;
+        EndOfStreamResponseCode status = 1;
 
         /**
          * The number of the last completed and _verified_ block.
@@ -220,45 +220,45 @@ message PublishStreamResponse {
          */
         uint64 block_number = 2;
     }
+}
+
+/**
+ * An enumeration indicating the status of this request.
+ *
+ * This enumeration describes the reason a block stream
+ * (sent via `writeBlockStream`) ended.
+ */
+enum EndOfStreamResponseCode {
+    /**
+     * An "unset value" flag, this value SHALL NOT be used.<br/>
+     * This status indicates the server software failed to set a
+     * status, and SHALL be considered a software defect.
+     */
+    STREAM_ITEMS_UNKNOWN = 0;
 
     /**
-     * An enumeration indicating the status of this request.
-     *
-     * This enumeration describes the reason a block stream
-     * (sent via `writeBlockStream`) ended.
+     * The request succeeded.<br/>
+     * No errors occurred and the source node orderly ended the stream.
      */
-    enum ResponseCode {
-        /**
-         * An "unset value" flag, this value SHALL NOT be used.<br/>
-         * This status indicates the server software failed to set a
-         * status, and SHALL be considered a software defect.
-         */
-        STREAM_ITEMS_UNKNOWN = 0;
+    STREAM_ITEMS_SUCCESS = 1;
 
-        /**
-         * The request succeeded.<br/>
-         * No errors occurred and the source node orderly ended the stream.
-         */
-        STREAM_ITEMS_SUCCESS = 1;
+    /**
+     * The delay between items was too long.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_TIMEOUT = 2;
 
-        /**
-         * The delay between items was too long.<br/>
-         * The source MUST start a new stream before the failed block.
-         */
-        STREAM_ITEMS_TIMEOUT = 2;
+    /**
+     * An item was received out-of-order.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_OUT_OF_ORDER = 3;
 
-        /**
-         * An item was received out-of-order.<br/>
-         * The source MUST start a new stream before the failed block.
-         */
-        STREAM_ITEMS_OUT_OF_ORDER = 3;
-
-        /**
-         * A block state proof item could not be validated.<br/>
-         * The source MUST start a new stream before the failed block.
-         */
-        STREAM_ITEMS_BAD_STATE_PROOF = 4;
-    }
+    /**
+     * A block state proof item could not be validated.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_BAD_STATE_PROOF = 4;
 }
 
 // ---- ReadBlock RPC ----
@@ -316,7 +316,7 @@ message SingleBlockResponse {
      * The reported status SHALL reflect the success of the request, or
      * a detailed reason the request failed.
      */
-    ResponseCode status = 1;
+    SingleBlockResponseCode status = 1;
 
     /**
      * The requested block.
@@ -329,48 +329,48 @@ message SingleBlockResponse {
      * a `BlockStateProof` applicable to this block.
      */
     com.hedera.hapi.block.stream.Block block = 2;
+}
 
-    /**
+/**
      * An enumeration indicating the status of this request.
      */
-    enum ResponseCode {
-        /**
-         * An "unset value" flag, this value SHALL NOT be used.<br/>
-         * This status indicates the server software failed to set a status,
-         * and SHALL be considered a software defect.
-         */
-        READ_BLOCK_UNKNOWN = 0;
+enum SingleBlockResponseCode {
+    /**
+     * An "unset value" flag, this value SHALL NOT be used.<br/>
+     * This status indicates the server software failed to set a status,
+     * and SHALL be considered a software defect.
+     */
+    READ_BLOCK_UNKNOWN = 0;
 
-        /**
-         * The requesting client account lacks sufficient HBAR to pay the
-         * service fee for this request.<br/>
-         * The client MAY retry the request, but MUST increase the client
-         * account balance with this block node server before doing so.
-         */
-        READ_BLOCK_INSUFFICIENT_BALANCE = 1;
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    READ_BLOCK_INSUFFICIENT_BALANCE = 1;
 
-        /**
-         * The request succeeded.<br/>
-         * The requested block SHALL be returned in the `block` field.
-         */
-        READ_BLOCK_SUCCESS = 2;
+    /**
+     * The request succeeded.<br/>
+     * The requested block SHALL be returned in the `block` field.
+     */
+    READ_BLOCK_SUCCESS = 2;
 
-        /**
-         * The requested block was not found.<br/>
-         * Something failed and a block that SHOULD be available was
-         * not found.<br/>
-         * The client MAY retry the request; if this result is repeated the
-         * request SHOULD be directed to a different block node server.
-         */
-        READ_BLOCK_NOT_FOUND = 3;
+    /**
+     * The requested block was not found.<br/>
+     * Something failed and a block that SHOULD be available was
+     * not found.<br/>
+     * The client MAY retry the request; if this result is repeated the
+     * request SHOULD be directed to a different block node server.
+     */
+    READ_BLOCK_NOT_FOUND = 3;
 
-        /**
-         * The requested block is not available on this block node server.<br/>
-         * The client SHOULD send a `serverStatus` request to determine the
-         * lowest and highest block numbers available at this block node server.
-         */
-        READ_BLOCK_NOT_AVAILABLE = 4;
-    }
+    /**
+     * The requested block is not available on this block node server.<br/>
+     * The client SHOULD send a `serverStatus` request to determine the
+     * lowest and highest block numbers available at this block node server.
+     */
+    READ_BLOCK_NOT_AVAILABLE = 4;
 }
 
 // ---- ReadBlockStream RPC ----
@@ -462,7 +462,7 @@ message SubscribeStreamResponse {
          * <p>
          * The block node server SHALL end the stream following this message.
          */
-        ResponseCode status = 1;
+        SubscribeStreamResponseCode status = 1;
 
         /**
          * A stream response item containing a single `BlockItem`.
@@ -472,55 +472,55 @@ message SubscribeStreamResponse {
          */
         com.hedera.hapi.block.stream.BlockItem block_item = 2;
     }
+}
 
+/**
+* An enumeration indicating the status of this request.
+*
+* This response code SHALL be the last message in the stream of responses.
+* This code SHALL represent the final status of the full request.
+*/
+enum SubscribeStreamResponseCode {
     /**
-     * An enumeration indicating the status of this request.
-     *
-     * This response code SHALL be the last message in the stream of responses.
-     * This code SHALL represent the final status of the full request.
-     */
-    enum ResponseCode {
-        /**
          * An "unset value" flag, this value SHALL NOT be used.<br/>
          * This status indicates the server software failed to set a status,
          * and SHALL be considered a software defect.
          */
-        READ_STREAM_UNKNOWN = 0;
+    READ_STREAM_UNKNOWN = 0;
 
-        /**
-         * The requesting client account lacks sufficient HBAR to pay the
-         * service fee for this request.<br/>
-         * The client MAY retry the request, but MUST increase the client
-         * account balance with this block node server before doing so.
-         */
-        READ_STREAM_INSUFFICIENT_BALANCE = 1;
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    READ_STREAM_INSUFFICIENT_BALANCE = 1;
 
-        /**
-         * The request succeeded.
-         * <p>
-         * The requested block(s) SHALL precede the status response
-         * with this value.
-         */
-        READ_STREAM_SUCCESS = 2;
+    /**
+     * The request succeeded.
+     * <p>
+     * The requested block(s) SHALL precede the status response
+     * with this value.
+     */
+    READ_STREAM_SUCCESS = 2;
 
-        /**
-         * The requested start block number is not valid.<br/>
-         * The start block number is after the end block number, less
-         * than `0`, or otherwise invalid.<br/>
-         * The client MAY retry this request, but MUST change the
-         * `start_block_number` field to a valid start block.
-         */
-        READ_STREAM_INVALID_START_BLOCK_NUMBER = 3;
+    /**
+     * The requested start block number is not valid.<br/>
+     * The start block number is after the end block number, less
+     * than `0`, or otherwise invalid.<br/>
+     * The client MAY retry this request, but MUST change the
+     * `start_block_number` field to a valid start block.
+     */
+    READ_STREAM_INVALID_START_BLOCK_NUMBER = 3;
 
-        /**
-         * The requested end block number is not valid.<br/>
-         * The end block number is greater than the highest current block
-         * number, less than `0`, or otherwise invalid.<br/>
-         * The client MAY retry this request, but MUST change the
-         * `end_block_number` field to a valid end block.
-         */
-        READ_STREAM_INVALID_END_BLOCK_NUMBER = 4;
-    }
+    /**
+     * The requested end block number is not valid.<br/>
+     * The end block number is greater than the highest current block
+     * number, less than `0`, or otherwise invalid.<br/>
+     * The client MAY retry this request, but MUST change the
+     * `end_block_number` field to a valid end block.
+     */
+    READ_STREAM_INVALID_END_BLOCK_NUMBER = 4;
 }
 
 // ---- StateSnapshot RPC ----
@@ -578,7 +578,7 @@ message StateSnapshotResponse {
      * This code SHALL indicate a successful call, or the detailed
      * reason for failure.
      */
-    ResponseCode status = 1;
+    StateSnapshotResponseCode status = 1;
 
     /**
      * A block number.
@@ -599,33 +599,33 @@ message StateSnapshotResponse {
      * </blockquote></blockquote>
      */
     string snapshot_reference = 3;
+}
 
+/**
+ * An enumeration indicating the status of a StateSnapshotResponse request.
+ */
+enum StateSnapshotResponseCode {
     /**
-     * An enumeration indicating the status of this request.
-     */
-    enum ResponseCode {
-        /**
          * An "unset value" flag, this value SHALL NOT be used.<br/>
          * This status indicates the server software failed to set a status,
          * and SHALL be considered a software defect.
          */
-        STATE_SNAPSHOT_UNKNOWN = 0;
+    STATE_SNAPSHOT_UNKNOWN = 0;
 
-        /**
-         * The requesting client account lacks sufficient HBAR to pay the
-         * service fee for this request.<br/>
-         * The client MAY retry the request, but MUST increase the client
-         * account balance with this block node server before doing so.
-         */
-        STATE_SNAPSHOT_INSUFFICIENT_BALANCE = 1;
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    STATE_SNAPSHOT_INSUFFICIENT_BALANCE = 1;
 
-        /**
-         * The request succeeded.<br/>
-         * The full snapshot data MAY be read via the endpoint provided in the
-         * `snapshot_reference` field for the duration specified.
-         */
-        STATE_SNAPSHOT_SUCCESS = 2;
-    }
+    /**
+     * The request succeeded.<br/>
+     * The full snapshot data MAY be read via the endpoint provided in the
+     * `snapshot_reference` field for the duration specified.
+     */
+    STATE_SNAPSHOT_SUCCESS = 2;
 }
 
 /**

--- a/block/block_service.proto
+++ b/block/block_service.proto
@@ -62,8 +62,8 @@ package com.hedera.hapi.block;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
-// <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
+option java_package = "com.hedera.hapi.block.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
 import "stream/block.proto";
@@ -206,7 +206,7 @@ message PublishStreamResponse {
          * This code indicates the reason the stream ended.<br/>
          * This value MUST be set to a non-default value.
          */
-        EndOfStreamResponseCode status = 1;
+        PublishStreamResponseCode status = 1;
 
         /**
          * The number of the last completed and _verified_ block.
@@ -228,7 +228,7 @@ message PublishStreamResponse {
  * This enumeration describes the reason a block stream
  * (sent via `writeBlockStream`) ended.
  */
-enum EndOfStreamResponseCode {
+enum PublishStreamResponseCode {
     /**
      * An "unset value" flag, this value SHALL NOT be used.<br/>
      * This status indicates the server software failed to set a

--- a/block/stream/block.proto
+++ b/block/stream/block.proto
@@ -36,7 +36,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block.proto
+++ b/block/stream/block.proto
@@ -36,7 +36,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block_header.proto
+++ b/block/stream/block_header.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -106,7 +106,7 @@ message BlockHeader {
      *         </ol>
      *       </li>
      *       <li>The second "internal" node SHALL be the parent of the
-     *           two "right-most" nodes.</li>
+     *           two "right-most" nodes.
      *         <ol>
      *           <li>The third leaf MUST be the root of a, strictly binary,
      *               merkle tree composed of all "output" block items in

--- a/block/stream/block_header.proto
+++ b/block/stream/block_header.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block_item.proto
+++ b/block/stream/block_item.proto
@@ -39,7 +39,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block_item.proto
+++ b/block/stream/block_item.proto
@@ -39,7 +39,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block_proof.proto
+++ b/block/stream/block_proof.proto
@@ -29,7 +29,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/block_proof.proto
+++ b/block/stream/block_proof.proto
@@ -29,7 +29,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/event_metadata.proto
+++ b/block/stream/event_metadata.proto
@@ -33,7 +33,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/event_metadata.proto
+++ b/block/stream/event_metadata.proto
@@ -33,7 +33,7 @@ package com.hedera.hapi.block.stream;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/input/system_transaction.proto
+++ b/block/stream/input/system_transaction.proto
@@ -46,7 +46,7 @@ package com.hedera.hapi.block.stream.input;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.input";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.input">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/input/system_transaction.proto
+++ b/block/stream/input/system_transaction.proto
@@ -46,7 +46,7 @@ package com.hedera.hapi.block.stream.input;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.input.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.input">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/consensus_service.proto
+++ b/block/stream/output/consensus_service.proto
@@ -35,7 +35,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -78,7 +78,7 @@ message SubmitMessageOutput {
      * For all current transactions, this value SHALL be
      * `WITH_MESSAGE_DIGEST_AND_PAYER`.
      */
-    SubmitMessageOutputRunningHashVersion topic_running_hash_version = 1;
+    RunningHashVersion topic_running_hash_version = 1;
 }
 
 /**
@@ -99,7 +99,7 @@ message SubmitMessageOutput {
  * All new transactions SHALL use `topic_running_hash_version`
  * `WITH_MESSAGE_DIGEST_AND_PAYER`.<br/>
  */
-enum SubmitMessageOutputRunningHashVersion {
+enum RunningHashVersion {
     /**
      * The most recent version.
      * <p>

--- a/block/stream/output/consensus_service.proto
+++ b/block/stream/output/consensus_service.proto
@@ -35,7 +35,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -78,90 +78,90 @@ message SubmitMessageOutput {
      * For all current transactions, this value SHALL be
      * `WITH_MESSAGE_DIGEST_AND_PAYER`.
      */
-    RunningHashVersion topic_running_hash_version = 1;
+    SubmitMessageOutputRunningHashVersion topic_running_hash_version = 1;
+}
+
+/**
+ * A version of the topic running hash.
+ *
+ * The inputs to the topic running hash have changed over time.
+ * This is tracked in earlier record streams as an integer. For the
+ * block stream we chose to use an enumeration for both efficiency
+ * and clarity. Placing the most recent, and most common/highest
+ * volume, version as `0` reduces the serialized size of this message
+ * by not serializing that default value.
+ *
+ * <hr style="margin: 0.2em 5em 0.2em 5em; height: 0.5em; border-style: solid none solid none; border-width: 2px;"/>
+ *
+ * The topic running hash is a 48-byte value that is the output
+ * of a SHA-384 digest with input data determined by the value of
+ * the `topic_running_hash_version` field.<br/>
+ * All new transactions SHALL use `topic_running_hash_version`
+ * `WITH_MESSAGE_DIGEST_AND_PAYER`.<br/>
+ */
+enum SubmitMessageOutputRunningHashVersion {
+    /**
+     * The most recent version.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The `topic_running_hash_version` field (8 bytes)</li>
+     *  <li>The payer account's shard (8 bytes)</li>
+     *  <li>The payer account's realm (8 bytes)</li>
+     *  <li>The payer account's number (8 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The output of a SHA-384 digest of the message bytes from the
+     *      `ConsensusSubmitMessage` (48 bytes)</li>
+     * </ol>
+     */
+    WITH_MESSAGE_DIGEST_AND_PAYER = 0;
 
     /**
-     * A version of the topic running hash.
-     *
-     * The inputs to the topic running hash have changed over time.
-     * This is tracked in earlier record streams as an integer. For the
-     * block stream we chose to use an enumeration for both efficiency
-     * and clarity. Placing the most recent, and most common/highest
-     * volume, version as `0` reduces the serialized size of this message
-     * by not serializing that default value.
-     *
-     * <hr style="margin: 0.2em 5em 0.2em 5em; height: 0.5em; border-style: solid none solid none; border-width: 2px;"/>
-     *
-     * The topic running hash is a 48-byte value that is the output
-     * of a SHA-384 digest with input data determined by the value of
-     * the `topic_running_hash_version` field.<br/>
-     * All new transactions SHALL use `topic_running_hash_version`
-     * `WITH_MESSAGE_DIGEST_AND_PAYER`.<br/>
+     * An earlier version.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The `topic_running_hash_version` field (8 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The output of a SHA-384 digest of the message bytes from the
+     *      `ConsensusSubmitMessage` (48 bytes)</li>
+     * </ol>
      */
-    enum RunningHashVersion {
-        /**
-         * The most recent version.
-         * <p>
-         * This version SHALL include, in order
-         * <ol>
-         *  <li>The previous running hash of the topic (48 bytes)</li>
-         *  <li>The `topic_running_hash_version` field (8 bytes)</li>
-         *  <li>The payer account's shard (8 bytes)</li>
-         *  <li>The payer account's realm (8 bytes)</li>
-         *  <li>The payer account's number (8 bytes)</li>
-         *  <li>The topic's shard (8 bytes)</li>
-         *  <li>The topic's realm (8 bytes)</li>
-         *  <li>The topic's number (8 bytes)</li>
-         *  <li>The number of seconds since the epoch when the
-         *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
-         *  <li>The number of nanoseconds within the second when the
-         *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
-         *  <li>The `topic_sequence_number` field (8 bytes)</li>
-         *  <li>The output of a SHA-384 digest of the message bytes from the
-         *      `ConsensusSubmitMessage` (48 bytes)</li>
-         * </ol>
-         */
-        WITH_MESSAGE_DIGEST_AND_PAYER = 0;
+    WITH_MESSAGE_DIGEST = 1;
 
-        /**
-         * An earlier version.
-         * <p>
-         * This version SHALL include, in order
-         * <ol>
-         *  <li>The previous running hash of the topic (48 bytes)</li>
-         *  <li>The `topic_running_hash_version` field (8 bytes)</li>
-         *  <li>The topic's shard (8 bytes)</li>
-         *  <li>The topic's realm (8 bytes)</li>
-         *  <li>The topic's number (8 bytes)</li>
-         *  <li>The number of seconds since the epoch when the
-         *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
-         *  <li>The number of nanoseconds within the second when the
-         *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
-         *  <li>The `topic_sequence_number` field (8 bytes)</li>
-         *  <li>The output of a SHA-384 digest of the message bytes from the
-         *      `ConsensusSubmitMessage` (48 bytes)</li>
-         * </ol>
-         */
-        WITH_MESSAGE_DIGEST = 1;
-
-        /**
-         * The original version, used at genesis.
-         * <p>
-         * This version SHALL include, in order
-         * <ol>
-         *  <li>The previous running hash of the topic (48 bytes)</li>
-         *  <li>The topic's shard (8 bytes)</li>
-         *  <li>The topic's realm (8 bytes)</li>
-         *  <li>The topic's number (8 bytes)</li>
-         *  <li>The number of seconds since the epoch when the
-         *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
-         *  <li>The number of nanoseconds within the second when the
-         *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
-         *  <li>The `topic_sequence_number` field (8 bytes)</li>
-         *  <li>The message bytes from the `ConsensusSubmitMessage`
-         *      (variable)</li>
-         * </ol>
-         */
-        WITH_FULL_MESSAGE = 2;
-    }
+    /**
+     * The original version, used at genesis.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The message bytes from the `ConsensusSubmitMessage`
+     *      (variable)</li>
+     * </ol>
+     */
+    WITH_FULL_MESSAGE = 2;
 }

--- a/block/stream/output/crypto_service.proto
+++ b/block/stream/output/crypto_service.proto
@@ -34,7 +34,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/crypto_service.proto
+++ b/block/stream/output/crypto_service.proto
@@ -34,7 +34,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/file_service.proto
+++ b/block/stream/output/file_service.proto
@@ -43,7 +43,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/file_service.proto
+++ b/block/stream/output/file_service.proto
@@ -43,7 +43,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/network_service.proto
+++ b/block/stream/output/network_service.proto
@@ -33,7 +33,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/network_service.proto
+++ b/block/stream/output/network_service.proto
@@ -33,7 +33,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/schedule_service.proto
+++ b/block/stream/output/schedule_service.proto
@@ -51,7 +51,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/schedule_service.proto
+++ b/block/stream/output/schedule_service.proto
@@ -51,7 +51,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/smart_contract_service.proto
+++ b/block/stream/output/smart_contract_service.proto
@@ -36,7 +36,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/smart_contract_service.proto
+++ b/block/stream/output/smart_contract_service.proto
@@ -36,7 +36,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/state_changes.proto
+++ b/block/stream/output/state_changes.proto
@@ -48,7 +48,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -229,17 +229,17 @@ message NewStateChange {
      * The type (e.g. Singleton, Virtual Map, Queue) of state to add.
      */
     NewStateType state_type = 1;
+}
 
-    /**
-     * An enumeration of the types of named states.<br/>
-     * The default, Singleton, is the type of state most frequently
-     * added and removed.
-     */
-    enum NewStateType {
-        SINGLETON = 0;
-        VIRTUAL_MAP = 1;
-        QUEUE = 2;
-    }
+/**
+ * An enumeration of the types of named states.<br/>
+ * The default, Singleton, is the type of state most frequently
+ * added and removed.
+ */
+enum NewStateType {
+    SINGLETON = 0;
+    VIRTUAL_MAP = 1;
+    QUEUE = 2;
 }
 
 /**
@@ -288,7 +288,7 @@ message SingletonUpdateChange {
         /**
          * A change to the exchange rates singleton.
          * <p>
-         * This change SHALL be present if the HBAR`<=>`USD exchange
+         * This change SHALL be present if the HBAR:USD exchange
          * rate, as stored in the "midnight rates" singleton changed
          * during the current block.
          */
@@ -553,24 +553,24 @@ message MapChangeValue {
          * An updated set of staking information for all nodes in
          * the address book.
          */
-        proto.StakingNodeInfo staking_node_info_value = 33;
+        proto.StakingNodeInfo staking_node_info_value = 10;
 
         /**
          * An HTS token value.
          */
-        proto.Token token_value = 10;
+        proto.Token token_value = 11;
 
         /**
          * A token relationship value.<br/>
          * These values track which accounts are willing to transact
          * in specific HTS tokens.
          */
-        proto.TokenRelation token_relation_value = 11;
+        proto.TokenRelation token_relation_value = 12;
 
         /**
          * An HCS topic value.
          */
-        proto.Topic topic_value = 12;
+        proto.Topic topic_value = 13;
     }
 }
 

--- a/block/stream/output/state_changes.proto
+++ b/block/stream/output/state_changes.proto
@@ -48,7 +48,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
@@ -288,7 +288,7 @@ message SingletonUpdateChange {
         /**
          * A change to the exchange rates singleton.
          * <p>
-         * This change SHALL be present if the HBAR:USD exchange
+         * This change SHALL be present if the <tt>HBAR&lt;=&gt;USD</tt> exchange
          * rate, as stored in the "midnight rates" singleton changed
          * during the current block.
          */

--- a/block/stream/output/token_service.proto
+++ b/block/stream/output/token_service.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/token_service.proto
+++ b/block/stream/output/token_service.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/transaction_output.proto
+++ b/block/stream/output/transaction_output.proto
@@ -31,7 +31,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/transaction_output.proto
+++ b/block/stream/output/transaction_output.proto
@@ -31,7 +31,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/transaction_result.proto
+++ b/block/stream/output/transaction_result.proto
@@ -29,7 +29,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/transaction_result.proto
+++ b/block/stream/output/transaction_result.proto
@@ -29,7 +29,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/util_service.proto
+++ b/block/stream/output/util_service.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hedera.hapi.block.stream.output";
+option java_package = "com.hederahashgraph.api.proto.java";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 

--- a/block/stream/output/util_service.proto
+++ b/block/stream/output/util_service.proto
@@ -30,7 +30,7 @@ package com.hedera.hapi.block.stream.output;
  * limitations under the License.
  */
 
-option java_package = "com.hederahashgraph.api.proto.java";
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 


### PR DESCRIPTION
**Description**:
This PR makes a few changes to the block stream protobuf definitions to allow PBJ to compile them.

1. ```java_package``` and ```pbj.java_package``` need to be different packages so the compiled java classes in hedera-services don't clash. Same with the generated tests.
2. Fixed two javadoc errors in ```block_header.proto``` and ```state_changes.proto```
3. Moved enum definitons outside of message definition and changed their name's.

**Notes for reviewer**:
Suggest any additional changes or renaming. Thanks for your time.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
