### PR TITLE
Add number of pending airdrops on `Account`

### DIFF
--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -219,7 +219,7 @@ message Account {
      * The number of pending airdrops owned by the account. This number is used to collect rent
      * for the account.
      */
-    int64 number_pending_airdrops = 35;
+    uint64 number_pending_airdrops = 35;
 }
 
 /**

--- a/services/state/token/account.proto
+++ b/services/state/token/account.proto
@@ -214,6 +214,12 @@ message Account {
      * pending airdrop, and SHALL be empty otherwise.
      */
     PendingAirdropId head_pending_airdrop_id = 34;
+
+    /**
+     * The number of pending airdrops owned by the account. This number is used to collect rent
+     * for the account.
+     */
+    int64 number_pending_airdrops = 35;
 }
 
 /**


### PR DESCRIPTION
Just like `num_owned_nfts` account need to track number of pending airdrops on the account, which is needed to calculate rent in the future.