### PR TITLE
feat: 14773 Created `PlatformVersion` message that adequately represents `PlatformState` version

### DIFF
--- a/platform/state/platform_state.proto
+++ b/platform/state/platform_state.proto
@@ -347,7 +347,9 @@ message NodeId {
  */
 message PlatformVersion {
     /**
-     * Version of the HAPI specification that was used to serialize the state.
+     * An API version.<br/>
+     * This is the Hedera API specification supported by the release of
+     * the Hashgraph Platform SDK that produced this message.
      */
     proto.SemanticVersion hapi_version = 1;
     /**

--- a/platform/state/platform_state.proto
+++ b/platform/state/platform_state.proto
@@ -352,6 +352,7 @@ message PlatformVersion {
      * the Hashgraph Platform SDK that produced this message.
      */
     proto.SemanticVersion hapi_version = 1;
+
     /**
      * A software version for the Hashgraph Platform SDK.<br/>
      * This is the version of the software that produced the state containing

--- a/platform/state/platform_state.proto
+++ b/platform/state/platform_state.proto
@@ -50,7 +50,7 @@ message PlatformState {
      * <p>
      * This SHALL be the software version that created this state.
      */
-    proto.SemanticVersion creation_software_version = 1;
+    PlatformVersion creation_software_version = 1;
 
     /**
      * A number of non-ancient rounds.
@@ -117,7 +117,7 @@ message PlatformState {
      * If birth round migration is complete, this SHALL be the _first_ software
      * version that enabled birth round mode.
     */
-    proto.SemanticVersion first_version_in_birth_round_mode = 10003 [deprecated = true];
+    PlatformVersion first_version_in_birth_round_mode = 10003 [deprecated = true];
 
     /**
      * An address book for this round.
@@ -338,4 +338,18 @@ message NodeId {
    * A numeric identifier.
    */
   uint64 id = 1;
+}
+
+/**
+ * A version of the platform software.
+ */
+message PlatformVersion {
+    /**
+     * Version of the HAPI specification that was used to serialize the state.
+     */
+    proto.SemanticVersion hapi_version = 1;
+    /**
+     * The software version of the state
+     */
+    proto.SemanticVersion software_version = 2;
 }

--- a/platform/state/platform_state.proto
+++ b/platform/state/platform_state.proto
@@ -341,7 +341,9 @@ message NodeId {
 }
 
 /**
- * A version of the platform software.
+ * A combined software version.<br/>
+ * This message describes both the API version and the software version
+ * supported by a release of the Hashgraph Platform SDK.
  */
 message PlatformVersion {
     /**

--- a/platform/state/platform_state.proto
+++ b/platform/state/platform_state.proto
@@ -351,7 +351,9 @@ message PlatformVersion {
      */
     proto.SemanticVersion hapi_version = 1;
     /**
-     * The software version of the state
+     * A software version for the Hashgraph Platform SDK.<br/>
+     * This is the version of the software that produced the state containing
+     * this message.
      */
     proto.SemanticVersion software_version = 2;
 }


### PR DESCRIPTION
**Description**:

This PR adds correct representation of the `PlatformState`  version that contains not only software version but HAPI version as well.

**Related issue(s)**:

Fixes # https://github.com/hashgraph/hedera-services/issues/14773

