### PR TITLE
fix: refine `BlockStreamInfo` message

### DIFF
--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -70,8 +70,8 @@ message BlockStreamInfo {
     /**
      * A concatenation of hash values.<br/>
      * This combines several trailing output block item hashes and
-     * is used as a seed value for a pseudo-random number generator and to
-     * implement the EVM `PREVRANDAO` opcode.
+     * is used as a seed value for a pseudo-random number generator.<br/>
+     * This is also requiried to implement the EVM `PREVRANDAO` opcode.
      */
     bytes trailing_output_hashes = 3;
 

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -53,7 +53,7 @@ option java_multiple_files = true;
 message BlockStreamInfo {
     /**
      * A block number.<br/>
-     * The number of the block this message describes.
+     * This is the current block number.
      */
     uint64 block_number = 1;
 

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -76,11 +76,13 @@ message BlockStreamInfo {
     bytes trailing_output_hashes = 3;
 
     /**
-     * A concatenation of up to 256 trailing block hashes.<br/>
+     * A concatenation of hash values.<br/>
+     * This field combines up to 256 trailing block hashes.
+     * <p>
      * If this message is for block number N, then the earliest available
-     * hash will be for block number N-256, and the latest available hash
-     * will be for block N-1. This is required to implement the EVM
-     * `BLOCKHASH` opcode.
+     * hash SHALL be for block number N-256.<br/>
+     * The latest available hash SHALL be for block N-1.<br/>
+     * This is REQUIRED to implement the EVM `BLOCKHASH` opcode.
      */
     bytes trailing_block_hashes = 4;
 }

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -37,11 +37,12 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * A message stored in state to maintain block stream parameters. Nodes use this
- * information for three purposes. First, to maintain hash chain continuity at
- * restart and reconnect boundaries. Second, to store historical hashes for
- * implementation of the EVM `BLOCKHASH` and `PREVRANDAO` opcodes. Third, to track
- * the amount of consensus time that has passed between blocks.
+ * A message stored in state to maintain block stream parameters.<br/>
+ * Nodes use this information for three purposes.
+ * 1. To maintain hash chain continuity at restart and reconnect boundaries.
+ * 1. To store historical hashes for implementation of the EVM `BLOCKHASH`
+ *    and `PREVRANDAO` opcodes.
+ * 1. To track the amount of consensus time that has passed between blocks.
  *
  * This value MUST be updated for every block.<br/>
  * This value MUST be transmitted in the "state changes" section of

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -37,7 +37,11 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * A message stored in state to maintain block stream parameters.
+ * A message stored in state to maintain block stream parameters. Nodes use this
+ * information for three purposes. First, to maintain hash chain continuity at
+ * restart and reconnect boundaries. Second, to store historical hashes for
+ * implementation of the EVM `BLOCKHASH` and `PREVRANDAO` opcodes. Third, to track
+ * the amount of consensus time that has passed between blocks.
  *
  * This value MUST be updated for every block.<br/>
  * This value MUST be transmitted in the "state changes" section of
@@ -48,36 +52,33 @@ option java_multiple_files = true;
 message BlockStreamInfo {
     /**
      * A block number.<br/>
-     * This is the block number of the last completed block.
+     * The number of the block this message describes.
      */
-    uint64 last_block_number = 1;
+    uint64 block_number = 1;
 
     /**
-     * A block hash value.<br/>
-     * This is the hash of the last completed block.
-     */
-    bytes last_block_hash = 2;
-
-    /**
-     * A consensus time for the last completed block.
+     * The first consensus time in this block.<br/>
      * This is used to determine if this block was the first across an
      * important boundary in consensus time, such as UTC midnight.
      * This may also be used to purge entities expiring between the last
      * block time and this time.
      */
-    proto.Timestamp last_block_time = 3;
+    proto.Timestamp block_time = 2;
 
     /**
      * A concatenation of hash values.<br/>
      * This combines several trailing output block item hashes and
-     * is used as a seed value for a pseudo-random number generator.
+     * is used as a seed value for a pseudo-random number generator and to
+     * implement the EVM `PREVRANDAO` opcode.
      */
-    bytes trailing_output_hashes = 4;
+    bytes trailing_output_hashes = 3;
 
     /**
-     * A concatenation of hash values.<br/>
-     * This combines the last 256 trailing block hashes, and is required to
-     * support the EVM `BLOCKHASH` opcode.
+     * A concatenation of up to 256 trailing block hashes.<br/>
+     * If this message is for block number N, then the earliest available
+     * hash will be for block number N-256, and the latest available hash
+     * will be for block N-1. This is required to implement the EVM
+     * `BLOCKHASH` opcode.
      */
-    bytes trailing_block_hashes = 5;
+    bytes trailing_block_hashes = 4;
 }

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -58,8 +58,9 @@ message BlockStreamInfo {
     uint64 block_number = 1;
 
     /**
-     * The first consensus time in this block.<br/>
-     * This is used to determine if this block was the first across an
+     * A consensus time for the current block.<br/>
+     * This is the _first_ consensus time in the current block, and
+     * is used to determine if this block was the first across an
      * important boundary in consensus time, such as UTC midnight.
      * This may also be used to purge entities expiring between the last
      * block time and this time.


### PR DESCRIPTION
**Description**:
Refines the `BlockStreamInfo` message.
  * Removes the `last_block_hash` field since the _N-1_ hash is already contained in `trailing_block_hashes`.
  * Removes the `last_` prefix on `block_number` and `block_time` as these values apply to the block with the given number.
  * Adds some comments to clarify the purpose of the message. 