### PR TITLE
chore: add needed `TransactionOutput` fields

### DIFF
--- a/block/stream/output/schedule_service.proto
+++ b/block/stream/output/schedule_service.proto
@@ -65,6 +65,17 @@ import "basic_types.proto";
  */
 message CreateScheduleOutput {
     /**
+     * A schedule identifier.
+     * <p>
+     * If the status of the transaction is `SUCCESS`, this value SHALL be
+     * set to the identifier of the schedule that was created. If the
+     * transaction status is `IDENTICAL_SCHEDULE_ALREADY_CREATED`, this
+     * value SHALL be set to the identifier of the existing schedule that
+     * is identical to the one that was attempted to be created. For any
+     * other status, this value SHALL NOT be set.
+     */
+    proto.ScheduleID schedule_id = 1;
+    /**
      * A scheduled transaction identifier.
      * <p>
      * This value SHALL be the transaction identifier for the _scheduled_

--- a/block/stream/output/smart_contract_service.proto
+++ b/block/stream/output/smart_contract_service.proto
@@ -135,7 +135,27 @@ message EthereumOutput {
     /**
      * An ethereum hash value.
      * <p>
-     * This SHALL be a keccak256 hash of the ethereumData.
+     * This SHALL be a keccak256 hash of the ethereumData, after
+     * interpolating the calldata from the referenced calldata file
+     * (if set).
      */
     bytes ethereum_hash = 2;
+
+    oneof eth_result {
+        /**
+         * A result for an Ethereum Transaction executed as a call.
+         * <p>
+         * This field SHALL contain all of the data produced by the contract
+         * call transaction as well as basic accounting results.
+         */
+        proto.ContractFunctionResult ethereum_call_result = 3;
+
+        /**
+         * A result for an Ethereum Transaction executed as a create.
+         * <p>
+         * This field SHALL contain all of the data produced by the contract
+         * create transaction as well as basic accounting results.
+         */
+        proto.ContractFunctionResult ethereum_create_result = 4;
+    }
 }

--- a/block/stream/output/token_service.proto
+++ b/block/stream/output/token_service.proto
@@ -34,6 +34,9 @@ option java_package = "com.hedera.hapi.block.stream.output.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
+import "custom_fees.proto";
+import "transaction_record.proto";
+
 /**
  * Block Stream data for a `createToken` transaction.
  *
@@ -161,3 +164,31 @@ message UnpauseTokenOutput {}
  * the original transaction.
  */
 message UpdateTokenNftsOutput {}
+
+/**
+ * Block Stream data for a `tokenAirdrop` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message TokenAirdropOutput {
+  /**
+   * Custom fees assessed during a TokenAirdrop.
+   * <p>
+   * These fees SHALL be present in the full transfer list for the transaction.
+   */
+  repeated proto.AssessedCustomFee assessed_custom_fees = 1;
+
+  /**
+   * A list of pending token airdrops.
+   * Each pending airdrop represents a single requested transfer from a
+   * sending account to a recipient account. These pending transfers are
+   * issued unilaterally by the sending account, and MUST be claimed by the
+   * recipient account before the transfer MAY complete.
+   * A sender MAY cancel a pending airdrop before it is claimed.
+   * An airdrop transaction SHALL emit a pending airdrop when the recipient has no
+   * available automatic association slots available or when the recipient
+   * has set `receiver_sig_required`.
+   */
+  repeated proto.PendingAirdropRecord new_pending_airdrops = 2;
+}

--- a/block/stream/output/transaction_output.proto
+++ b/block/stream/output/transaction_output.proto
@@ -38,6 +38,7 @@ option java_multiple_files = true;
 import "stream/output/schedule_service.proto";
 import "stream/output/util_service.proto";
 import "stream/output/crypto_service.proto";
+import "stream/output/token_service.proto";
 import "stream/output/smart_contract_service.proto";
 
 /**
@@ -149,5 +150,10 @@ message TransactionOutput {
          * executing the scheduled transaction.
          */
         SignScheduleOutput sign_schedule = 7;
+
+        /**
+         * Output from a token airdrop transaction.
+         */
+        TokenAirdropOutput token_airdrop = 8;
     }
 }

--- a/services/state/blockstream/block_stream_info.proto
+++ b/services/state/blockstream/block_stream_info.proto
@@ -59,8 +59,8 @@ message BlockStreamInfo {
 
     /**
      * A consensus time for the current block.<br/>
-     * This is the _first_ consensus time in the current block, and
-     * is used to determine if this block was the first across an
+     * This is the consensus time of the first round in the current block,
+     * and is used to determine if this block was the first across an
      * important boundary in consensus time, such as UTC midnight.
      * This may also be used to purge entities expiring between the last
      * block time and this time.
@@ -72,6 +72,7 @@ message BlockStreamInfo {
      * This combines several trailing output block item hashes and
      * is used as a seed value for a pseudo-random number generator.<br/>
      * This is also requiried to implement the EVM `PREVRANDAO` opcode.
+     * This MUST contain at least 256 bits of entropy.
      */
     bytes trailing_output_hashes = 3;
 
@@ -83,6 +84,12 @@ message BlockStreamInfo {
      * hash SHALL be for block number N-256.<br/>
      * The latest available hash SHALL be for block N-1.<br/>
      * This is REQUIRED to implement the EVM `BLOCKHASH` opcode.
+     * <p>
+     * <div style="display: block;font-size: .83em;margin-top: 1.67em;margin-bottom: 1.67em;margin-left: 0;margin-right: 0;font-weight: bold;">Field Length</div>
+     * Each hash value SHALL be the trailing 265 bits of a SHA2-384 hash.<br/>
+     * The length of this field SHALL be an integer multiple of 32 bytes.<br/>
+     * This field SHALL be at least 32 bytes.<br/>
+     * The maximum length of this field SHALL be 8192 bytes.
      */
     bytes trailing_block_hashes = 4;
 }


### PR DESCRIPTION
**Description**:
 - Adds `TransactionOutput` fields for `SCHEDULE_CREATE`, `TOKEN_AIRDROP`, and `ETHEREUM_TRANSACTION` that are necessary to recover the full record stream from the block stream.