### PR TITLE
chore: Update roster_entries variable name in  roster.proto

### DIFF
--- a/services/state/roster/roster.proto
+++ b/services/state/roster/roster.proto
@@ -37,7 +37,7 @@ message Roster {
      * This list SHALL contain roster entries in natural order of ascending node ids.
      * This list SHALL NOT be empty.<br/>
      */
-    repeated RosterEntry rosters = 1;
+    repeated RosterEntry roster_entries = 1;
 }
 
 /**


### PR DESCRIPTION
The variable name has been updated by https://github.com/hashgraph/hedera-services/pull/15465 in the hedera-serivces repo. 
