### PR TITLE
feat: Protocol Buffer modifications for HIP 1046

### DIFF
--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -1437,6 +1437,52 @@ message ServiceEndpoint {
      * When the `ipAddressV4` field is set, the `domain_name` field MUST NOT be set.
      */
     string domain_name = 3;
+
+    /**
+     * A purpose for this service endpoint.<br/>
+     * This is one of several options, including a gossip endpoint,
+     * a gRPC endpoint, or a gRPC-Web Proxy endpoint, among others.
+     * <p>
+     * This field is REQUIRED.<br/>
+     * This field MUST match the actual purpose of this endpoint.
+     */
+    ServiceEndpointPurpose purpose = 4;
+}
+
+/**
+ * An enumeration of possible "purpose" values.<br/>
+ * This enumeration is used to describe the purpose of each `ServiceEndpoint`
+ * entry in a list of service endpoints. The canonical use is to describe
+ * the service endpoint purpose for values in the `service_endpoint` field
+ * of a `Node`.
+ */
+enum ServiceEndpointPurpose {
+    /**
+     * An endpoint used to gossip transactions or other data.
+     */
+    GOSSIP = 0;
+
+    /**
+     * An endpoint that provides a TLS secured gRPC API.
+     */
+    SECURE_GRPC = 1;
+
+    /**
+     * An endpoint that provides an un-secured gRPC API.
+     */
+    INSECURE_GRPC = 2;
+
+    /**
+     * An endpoint that provides a TLS secured web proxy for gRPC requests
+     * from clients that cannot directly connect to gRPC endpoints.
+     */
+    SECURE_GRPC_WEB_PROXY = 3;
+
+    /**
+     * An endpoint that provides an un-secured web proxy for gRPC requests
+     * from clients that cannot directly connect to gRPC endpoints.
+     */
+    INSECURE_GRPC_WEB_PROXY = 4;
 }
 
 /**

--- a/services/node_create.proto
+++ b/services/node_create.proto
@@ -76,6 +76,7 @@ message NodeCreateTransactionBody {
      * consensus nodes may _gossip_ transactions.<br/>
      * These endpoints MUST specify a port.<br/>
      * This list MUST NOT be empty.<br/>
+     * Every endpoint in this list MUST have the "Gossip" purpose.<br/>
      * This list MUST NOT contain more than `10` entries.<br/>
      * The first two entries in this list SHALL be the endpoints published to
      * all consensus nodes.<br/>
@@ -101,6 +102,10 @@ message NodeCreateTransactionBody {
      * Endpoints in this list MAY supply either IP address or FQDN, but MUST
      * NOT supply both values for the same endpoint.<br/>
      * This list MUST NOT be empty.<br/>
+     * There MUST NOT be any endpoint in this list with "Gossip" purpose.<br/>
+     * There MUST NOT be more than one "secure gRPC" endpoint in this list.<br/>
+     * If this list contains a "secure gRPC" endpoint, it SHOULD NOT contain an
+     * "insecure gRPC endpoint.<br/>
      * This list MUST NOT contain more than `8` entries.
      */
     repeated proto.ServiceEndpoint service_endpoint = 4;

--- a/services/node_update.proto
+++ b/services/node_update.proto
@@ -82,6 +82,7 @@ message NodeUpdateTransactionBody {
      * consensus nodes may _gossip_ transactions.<br/>
      * These endpoints SHOULD NOT specify both address and DNS name.<br/>
      * This list MUST NOT be empty.<br/>
+     * Every endpoint in this list MUST have the "Gossip" purpose.<br/>
      * This list MUST NOT contain more than `10` entries.<br/>
      * The first two entries in this list SHALL be the endpoints published to
      * all consensus nodes.<br/>
@@ -116,6 +117,10 @@ message NodeUpdateTransactionBody {
      * These endpoints MAY specify a DNS name.<br/>
      * These endpoints SHOULD NOT specify both address and DNS name.<br/>
      * This list MUST NOT be empty.<br/>
+     * There MUST NOT be any endpoint in this list with "Gossip" purpose.<br/>
+     * There MUST NOT be more than one "secure gRPC" endpoint in this list.<br/>
+     * If this list contains a "secure gRPC" endpoint, it SHOULD NOT contain an
+     * "insecure gRPC endpoint.<br/>
      * This list MUST NOT contain more than `8` entries.
      * <p>
      * Each network may have additional requirements for these endpoints.

--- a/services/state/addressbook/node.proto
+++ b/services/state/addressbook/node.proto
@@ -72,6 +72,7 @@ message Node {
      * then endpoints in this list MAY supply either IP address or FQDN, but
      * SHALL NOT supply both values for the same endpoint.<br/>
      * This list SHALL NOT be empty.<br/>
+     * Every endpoint in this list SHALL have the "Gossip" purpose.<br/>
      * This list SHALL NOT contain more than `10` entries.<br/>
      * The first two entries in this list SHALL be the endpoints published to
      * all consensus nodes.<br/>
@@ -80,7 +81,7 @@ message Node {
     repeated proto.ServiceEndpoint gossip_endpoint = 4;
 
     /**
-     * A list of service endpoints for gRPC calls.
+     * A list of service endpoints for client calls.
      * <p>
      * These endpoints SHALL represent the published endpoints to which clients
      * may submit transactions.<br/>
@@ -88,6 +89,10 @@ message Node {
      * Endpoints in this list MAY supply either IP address or FQDN, but SHALL
      * NOT supply both values for the same endpoint.<br/>
      * This list SHALL NOT be empty.<br/>
+     * There SHALL NOT be any endpoint in this list with "Gossip" purpose.<br/>
+     * There SHALL NOT be more than one "secure gRPC" endpoint in this list.<br/>
+     * If this list contains a "secure gRPC" endpoint, it SHOULD NOT contain an
+     * "insecure gRPC endpoint.<br/>
      * This list SHALL NOT contain more than `8` entries.
      */
     repeated proto.ServiceEndpoint service_endpoint = 5;


### PR DESCRIPTION
* Added a `ServiceEndpointPurpose` enum.
* Modified `ServiceEndpoint` to include a `ServiceEndpointPurpose` field `purpose`.
* Updated specification for `Node`, `NodeCreateTransactionBody`, and `NodeUpdateTransactionBody` to specify requirements for `gossip_endpoint` and `service_endpoint` lists.
