### PR TITLE
Add HIP-796 partition and lock keys

### DIFF
--- a/services/token_get_info.proto
+++ b/services/token_get_info.proto
@@ -209,6 +209,35 @@ message TokenInfo {
      * (token definition and individual NFTs).
      */
     Key metadata_key = 28;
+
+    /**
+      * A function-specific account key.<br/>
+      * This key authorizes transactions to lock tokens in an account or account
+      * partition.
+      * <p>
+      * The key SHALL be used to authorize the locking and unlocking of tokens,
+      * or the transfer of locked tokens on balances held by the user
+      * on their account, or on the partition in their account.
+      */
+    Key lock_key = 29;
+
+    /**
+     * A function-specific account key.<br/>
+     * held by an account.
+     * <p>
+     * This key SHALL be used to authorize the creation, deletion, or updating
+     * of partition definitions owned by the token definition.
+     */
+    Key partition_key = 30;
+
+    /**
+     * A function-specific account key.<br/>
+     * This key authorizes transactions to move tokens between partitions.
+     * <p>
+     * This key SHALL be used to authorize the movement of tokens between
+     * partitions.
+     */
+    Key partition_move_key = 31;
 }
 
 /**

--- a/services/token_get_info.proto
+++ b/services/token_get_info.proto
@@ -223,6 +223,7 @@ message TokenInfo {
 
     /**
      * A function-specific account key.<br/>
+     * This key authorizes transactions to partition fungible tokens and NFTs
      * held by an account.
      * <p>
      * This key SHALL be used to authorize the creation, deletion, or updating


### PR DESCRIPTION
**Description**:
The `HIP-796 keys` that were added to services need to be put in sync with `hedera-protobufs `

**Related issue(s)**:

Fixes #433 

