### PR TITLE
Removed incorrect specification for node id in receipt

### DIFF
--- a/services/node_delete.proto
+++ b/services/node_delete.proto
@@ -36,9 +36,8 @@ option java_multiple_files = true;
  * - A deleted address book node SHALL be removed entirely from network state.
  * - A deleted address book node identifier SHALL NOT be reused.
  *
- * ### Record Stream Effects
- * Upon completion the "deleted" `node_id` SHALL be in the transaction
- * receipt.
+ * ### Block Stream Effects
+ * None.
  */
 message NodeDeleteTransactionBody {
     /**

--- a/services/node_update.proto
+++ b/services/node_update.proto
@@ -41,9 +41,8 @@ import "basic_types.proto";
  *   configuration during the next `freeze` transaction with the field
  *   `freeze_type` set to `PREPARE_UPGRADE`.
  *
- * ### Record Stream Effects
- * Upon completion the `node_id` for the updated entry SHALL be in the
- * transaction receipt.
+ * ### Block Stream Effects
+ * None.
  */
 message NodeUpdateTransactionBody {
     /**
@@ -91,9 +90,7 @@ message NodeUpdateTransactionBody {
      * details.<br/>
      * <blockquote>Example<blockquote>
      * Hedera Mainnet _requires_ that address be specified, and does not
-     * permit DNS name (FQDN) to be specified.<br/>
-     * Mainnet also requires that the first entry be an "internal" IP
-     * address and the second entry be an "external" IP address.
+     * permit DNS name (FQDN) to be specified.
      * </blockquote>
      * <blockquote>
      * Solo, however, _requires_ DNS name (FQDN) but also permits

--- a/services/transaction_receipt.proto
+++ b/services/transaction_receipt.proto
@@ -168,11 +168,10 @@ message TransactionReceipt {
     repeated int64 serialNumbers = 14;
 
     /**
-     * In the receipt of a NodeCreate, NodeUpdate, NodeDelete, the id of the newly created node.
      * An affected node identifier.<br/>
+     * In the receipt of a NodeCreate, the id of the newly created node.
+     * <p>
      * This value SHALL be set following a `createNode` transaction.<br/>
-     * This value SHALL be set following a `updateNode` transaction.<br/>
-     * This value SHALL be set following a `deleteNode` transaction.<br/>
      * This value SHALL NOT be set following any other transaction.
      */
     uint64 node_id = 15;


### PR DESCRIPTION
Very small update to fix some documentation-only errors in the protocol buffer specification for Node update/delete and transaction receipt.