### PR TITLE
fix: Adjust Block Stream to ensure a newly created account is identifiable

### DIFF
--- a/block/stream/output/crypto_service.proto
+++ b/block/stream/output/crypto_service.proto
@@ -39,6 +39,7 @@ option java_package = "com.hedera.hapi.block.stream.output.protoc";
 option java_multiple_files = true;
 
 import "custom_fees.proto";
+import "basic_types.proto";
 
 /**
  * Block Stream data for a `approveAllowances` transaction.
@@ -62,7 +63,20 @@ message DeleteAllowanceOutput {}
  * This message SHALL NOT duplicate information already contained in
  * the original transaction.
  */
-message CreateAccountOutput {}
+message CreateAccountOutput {
+    /**
+     * A newly created account identifier.<br/>
+     * This is the account identifier for the account created as part of
+     * any transaction that creates a new account.<br/>
+     * This value is necessary due to the difficulty of otherwise identifying
+     * created accounts versus the other account updates necessary for every
+     * transaction (e.g. fee payment).
+     * <p>
+     * This value SHALL be set for every account creation.
+     * This value SHALL NOT be set if no account is created.
+     */
+    proto.AccountID created_account = 1;
+}
 
 /**
  * Block Stream data for a `cryptoDelete` transaction.

--- a/block/stream/output/transaction_output.proto
+++ b/block/stream/output/transaction_output.proto
@@ -57,9 +57,6 @@ import "stream/output/consensus_service.proto";
  *
  * <!--
  * Reserved definitions:
- * import "stream/output/consensus_service.proto";
- *    SubmitMessageOutput submit_message;
- *
  * import "stream/smart_contract_service.proto";
  *    UpdateContractOutput contract_update;
  *    DeleteContractOutput contract_delete;
@@ -80,7 +77,6 @@ import "stream/output/consensus_service.proto";
  *    UpdateNodeStakeOutput update_node_stake;
  *    ApproveAllowanceOutput approve_allowance;
  *    DeleteAllowanceOutput delete_allowance;
- *    CreateAccountOutput create_account;
  *    UpdateAccountOutput update_account;
  *    DeleteAccountOutput delete_account;
  *
@@ -161,5 +157,11 @@ message TransactionOutput {
          * Output from a consensus submit message transaction.
          */
         SubmitMessageOutput submit_message = 9;
+
+        /**
+         * Output from a transaction that includes the creation of a new
+         * CryptoService Account.
+         */
+        CreateAccountOutput account_create = 10;
     }
 }


### PR DESCRIPTION
* Added a created account ID to the CreateAccountOutput.
* Added CreateAccountOutput to the TransactionOutput oneOf.
