### PR TITLE
Remove Previous Block Hash from Header

### DIFF
--- a/block/stream/block_proof.proto
+++ b/block/stream/block_proof.proto
@@ -98,12 +98,62 @@ message BlockProof {
     uint64 block = 1;
 
     /**
-     * A merkle root hash of the previous block.
+     * A block root hash for the previous block.
      * <p>
-     * This MUST contain a hash of the "block" merkle tree root for the
-     * previous block.<br/>
-     * The hash algorithm used MUST match the algorithm declared in the
-     * block header _for that block_.
+     * This value MUST match the block merkle tree root hash of the previous
+     * block in the block stream.<br/>
+     * This value SHALL be empty for the genesis block, and SHALL NOT be empty
+     * for any other block.<br/>
+     * Client systems SHOULD optimistically reject any block with a
+     * `previous_block_proof_hash` that does not match the block hash of the
+     * previous block and MAY assume the block stream has encountered data
+     * loss, data corruption, or unauthorized modification.
+     * <p>
+     * The process for computing a block hash is somewhat complex, and involves
+     * creating a "virtual" merkle tree to obtain the root merkle hash of
+     * that virtual tree.<br/>
+     * The merkle tree SHALL have a 4 part structure with 2 internal nodes,
+     * structured in a strictly binary tree.
+     * <ul>
+     *   <li>The merkle tree root SHALL be the parent of both
+     *       internal nodes.
+     *     <ol>
+     *       <li>The first "internal" node SHALL be the parent of the
+     *           two "left-most" nodes.
+     *         <ol>
+     *           <li>The first leaf MUST be the previous block hash, and is a
+     *               single 48-byte value.</li>
+     *           <li>The second leaf MUST be the root of a, strictly binary,
+     *               merkle tree composed of all "input" block items in
+     *               the block.<br/>
+     *               Input items SHALL be transactions, system transactions,
+     *               and events.<br/>
+     *               Leaf nodes in this subtree SHALL be ordered in the
+     *               same order that the block items are encountered
+     *               in the stream.</li>
+     *         </ol>
+     *       </li>
+     *       <li>The second "internal" node SHALL be the parent of the
+     *           two "right-most" nodes.
+     *         <ol>
+     *           <li>The third leaf MUST be the root of a, strictly binary,
+     *               merkle tree composed of all "output" block items in
+     *               the block.<br/>
+     *               Output items SHALL be transaction result, transaction
+     *               output, and state changes.<br/>
+     *               Leaf nodes in this subtree SHALL be ordered in the
+     *               same order that the block items are encountered
+     *               in the stream.</li>
+     *           <li>The fourth leaf MUST be the merkle tree root hash for
+     *               network state at the start of the block, and is a single
+     *               48-byte value.</li>
+     *         </ol>
+     *       </li>
+     *     </ol>
+     *   </li>
+     *   <li>The block hash SHALL be the SHA-384 hash calculated for the root
+     *       of this merkle tree.</li>
+     * </ul>
      */
     bytes previous_block_root_hash = 2;
 

--- a/block/stream/output/block_header.proto
+++ b/block/stream/output/block_header.proto
@@ -79,77 +79,17 @@ message BlockHeader {
     uint64 number = 3;
 
     /**
-     * A block root hash for the previous block.
-     * <p>
-     * This value MUST match the block merkle tree root hash of the previous
-     * block in the block stream.<br/>
-     * This value SHALL be empty for the genesis block, and SHALL NOT be empty
-     * for any other block.<br/>
-     * Client systems SHOULD optimistically reject any block with a
-     * `previous_block_proof_hash` that does not match the block hash of the
-     * previous block and MAY assume the block stream has encountered data
-     * loss, data corruption, or unauthorized modification.
-     * <p>
-     * The process for computing a block hash is somewhat complex, and involves
-     * creating a "virtual" merkle tree to obtain the root merkle hash of
-     * that virtual tree.<br/>
-     * The merkle tree SHALL have a 4 part structure with 2 internal nodes,
-     * structured in a strictly binary tree.
-     * <ul>
-     *   <li>The merkle tree root SHALL be the parent of both
-     *       internal nodes.
-     *     <ol>
-     *       <li>The first "internal" node SHALL be the parent of the
-     *           two "left-most" nodes.
-     *         <ol>
-     *           <li>The first leaf MUST be the previous block hash, and is a
-     *               single 48-byte value.</li>
-     *           <li>The second leaf MUST be the root of a, strictly binary,
-     *               merkle tree composed of all "input" block items in
-     *               the block.<br/>
-     *               Input items SHALL be transactions, system transactions,
-     *               and events.<br/>
-     *               Leaf nodes in this subtree SHALL be ordered in the
-     *               same order that the block items are encountered
-     *               in the stream.</li>
-     *         </ol>
-     *       </li>
-     *       <li>The second "internal" node SHALL be the parent of the
-     *           two "right-most" nodes.
-     *         <ol>
-     *           <li>The third leaf MUST be the root of a, strictly binary,
-     *               merkle tree composed of all "output" block items in
-     *               the block.<br/>
-     *               Output items SHALL be transaction result, transaction
-     *               output, and state changes.<br/>
-     *               Leaf nodes in this subtree SHALL be ordered in the
-     *               same order that the block items are encountered
-     *               in the stream.</li>
-     *           <li>The fourth leaf MUST be the merkle tree root hash for
-     *               network state at the start of the block, and is a single
-     *               48-byte value.</li>
-     *         </ol>
-     *       </li>
-     *     </ol>
-     *   </li>
-     *   <li>The block hash SHALL be the SHA-384 hash calculated for the root
-     *       of this merkle tree.</li>
-     * </ul>
-     */
-    bytes previous_block_hash = 4;
-
-    /**
      * A consensus timestamp for the start of this block.
      * <p>
      * This SHALL be the timestamp assigned by the hashgraph consensus
      * algorithm to the first transaction of this block.
      */
-    proto.Timestamp first_transaction_consensus_time = 5;
+    proto.Timestamp first_transaction_consensus_time = 4;
 
     /**
      * A hash algorithm used for this block, including the block proof.
      * <p>
      * This SHOULD always be `SHA2_384`, currently.
      */
-    proto.BlockHashAlgorithm hash_algorithm = 6;
+    proto.BlockHashAlgorithm hash_algorithm = 5;
 }


### PR DESCRIPTION
**Description**:
The previousBlockHash is no longer required in the Block Stream BlockHeader because it causes a timing problem that prevents optimal parallel thread pipelining in the consensus node and we do not want to hold up creating the block header until that hash is ready. It will continue to be available in the Block Proof however.

**Related issue(s)**:

Fixes #468 
