### PR TITLE
fix: add missing import in `transaction_result.proto`

### DIFF
--- a/block/stream/output/transaction_result.proto
+++ b/block/stream/output/transaction_result.proto
@@ -34,6 +34,7 @@ option java_package = "com.hedera.hapi.block.stream.output.protoc";
 option java_multiple_files = true;
 
 import "basic_types.proto";
+import "custom_fees.proto";
 import "response_code.proto";
 import "timestamp.proto";
 


### PR DESCRIPTION
**Description**:
This PR fixes missing import in `transaction_result.proto`, which breaks compiling.
It was introduced from the previous two commits, which imported the protobuf changes from services.
Here is in services this import https://github.com/hiero-ledger/hiero-consensus-node/blob/v0.61.1/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/output/transaction_result.proto#L22

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
