### PR TITLE
chore: Sync with hiero-consensus-node v0.62.2

### DIFF
--- a/block/stream/block_proof.proto
+++ b/block/stream/block_proof.proto
@@ -177,6 +177,21 @@ message BlockProof {
      * the value of `block_signature`.
      */
     repeated MerkleSiblingHash sibling_hashes = 5;
+
+    oneof verification_reference {
+        /**
+         * The id of the hinTS scheme this signature verifies under.
+         */
+        uint64 scheme_id = 6;
+
+        /**
+         * The explicit hinTS key this signature verifies under; useful when
+         * the verifier can easily check whether a chain-of-trust proof
+         * exists for a key, but does does not have any context of the
+         * latest hinTS schemes published in the block stream.
+         */
+        bytes verification_key = 7;
+    }
 }
 
 /**

--- a/block/stream/input/event_metadata.proto
+++ b/block/stream/input/event_metadata.proto
@@ -34,6 +34,7 @@ option java_package = "com.hedera.hapi.block.stream.input.protoc";
 option java_multiple_files = true;
 
 import "event/event_core.proto";
+import "event/event_descriptor.proto";
 
 /**
  * A header for a single event.<br/>
@@ -42,14 +43,34 @@ import "event/event_core.proto";
 message EventHeader {
     /**
      * An event core value.<br/>
-     * This provides information about the event creator and the event
-     * "parents". Event "parents" includes the "self parent" if any.
      */
     com.hedera.hapi.platform.event.EventCore event_core = 1;
 
     /**
-     * A single node event signature.<br/>
-     * This is the event creator's signature for this event.
+    * A list of references to parent events. <br/>
+    */
+    repeated ParentEventReference parents = 2;
+
+    /**
+     * The middle bit of the node's signature on the event.<br/>
      */
-    bytes signature = 2;
+    bool signature_middle_bit = 3;
+}
+
+/*
+ * A reference to a parent event.
+ */
+message ParentEventReference {
+
+    oneof parent {
+        /**
+         * An EventDescriptor for the parent event outside of the containing block.
+         */
+        com.hedera.hapi.platform.event.EventDescriptor event_descriptor = 1;
+
+        /**
+         * An index of the parent event within the containing block.
+         */
+        uint32 index = 2;
+    }
 }

--- a/block/stream/output/block_header.proto
+++ b/block/stream/output/block_header.proto
@@ -79,12 +79,27 @@ message BlockHeader {
     uint64 number = 3;
 
     /**
-     * A consensus timestamp for the start of this block.
+     * The timestamp for this block.<br/>
+     * The block timestamp is the consensus time stamp of the first round
+     * in the block.
      * <p>
-     * This SHALL be the timestamp assigned by the hashgraph consensus
-     * algorithm to the first transaction of this block.
+     * This SHALL be a timestamp for the block, determined as follows:<br/>
+     * Given the first round within a block
+     * <ul>
+     *  <li>If the round contains events and transactions, the
+     *       timestamp SHALL be the timestamp of the last transaction in
+     *       the round.</li>
+     *  <li>If the round has events but no transactions the timestamp
+     *      SHALL be the timestamp of the last event in the round.</li>
+     *  <li>If the round contains no events or transactions, the
+     *      timestamp SHALL be the timestamp of the previous round plus
+     *      1000 nanoseconds.</li>
+     *  <li>If the round contains no events or transactions and there
+     *      is no previous round, the timestamp SHALL be the median of
+     *      the judge created timestamps for this round.</li>
+     * </ul>
      */
-    proto.Timestamp first_transaction_consensus_time = 4;
+    proto.Timestamp block_timestamp = 4;
 
     /**
      * A hash algorithm used for this block, including the block proof.

--- a/platform/event/event_core.proto
+++ b/platform/event/event_core.proto
@@ -70,8 +70,10 @@ message EventCore {
    * The list of parents SHALL include zero or one self parents, and zero or more other parents.<br/>
    * The first element of the list SHALL be the self parent, if one exists.<br/>
    * The list of parents SHALL NOT include more than one parent from the same creator.
+   * <p>
+   * This field is deprecated and can be removed in release 0.62
    */
-  repeated EventDescriptor parents = 4;
+  repeated EventDescriptor parents = 4 [deprecated = true];
 
   /**
    * The event specification version.<br/>

--- a/platform/event/gossip_event.proto
+++ b/platform/event/gossip_event.proto
@@ -30,6 +30,7 @@ package com.hedera.hapi.platform.event;
  */
 
 import "event/event_core.proto";
+import "event/event_descriptor.proto";
 
 option java_package = "com.hedera.hapi.platform.event.legacy";
 // <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
@@ -71,4 +72,17 @@ message GossipEvent {
    * included in this gossip event.
    */
   repeated bytes transactions = 4;
+
+  /**
+   * A list of EventDescriptors representing the parents of this event.<br/>
+   * The list of parents SHALL include zero or one self parents, and zero or more other parents.<br/>
+   * The first element of the list SHALL be the self parent, if one exists.<br/>
+   * The list of parents SHALL NOT include more than one parent from the same creator.
+   * <p>
+   * NOTE: This field is currently being migrated from EventCore to GossipEvent.
+   * Once the migration is complete, this field will be removed from EventCore.
+   * While migration is ongoing, the expectation is that only one of the two
+   * fields will be set, but not both.
+   */
+  repeated EventDescriptor parents = 5;
 }

--- a/services/basic_types.proto
+++ b/services/basic_types.proto
@@ -732,6 +732,12 @@ enum SubType {
      * with custom fees.
      */
     TOPIC_CREATE_WITH_CUSTOM_FEES = 6;
+
+    /**
+     * The resource cost for the transaction type includes a ConsensusSubmitMessage
+     * for a topic with custom fees.
+     */
+    SUBMIT_MESSAGE_WITH_CUSTOM_FEES = 7;
 }
 
 /**

--- a/services/node_create.proto
+++ b/services/node_create.proto
@@ -149,4 +149,17 @@ message NodeCreateTransactionBody {
      * node rewards.<br/>
      */
     bool decline_reward = 8;
+
+    /**
+     * A web proxy for gRPC from non-gRPC clients.
+     * <p>
+     * This endpoint SHALL be a Fully Qualified Domain Name (FQDN) using the HTTPS
+     * protocol, and SHALL support gRPC-Web for use by browser-based clients.<br/>
+     * This endpoint MUST be signed by a trusted certificate authority.<br/>
+     * This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
+     * This field MAY be omitted if the node does not support gRPC-Web access.<br/>
+     * This field MUST be updated if the gRPC-Web endpoint changes.<br/>
+     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+     */
+    proto.ServiceEndpoint grpc_proxy_endpoint = 9;
 }

--- a/services/node_update.proto
+++ b/services/node_update.proto
@@ -167,4 +167,17 @@ message NodeUpdateTransactionBody {
      * This node SHALL NOT receive reward if this value is set, and `true`.
      */
     google.protobuf.BoolValue decline_reward = 9;
+
+    /**
+     * A web proxy for gRPC from non-gRPC clients.
+     * <p>
+     * This endpoint SHALL be a Fully Qualified Domain Name (FQDN) using the HTTPS
+     * protocol, and SHALL support gRPC-Web for use by browser-based clients.<br/>
+     * This endpoint MUST be signed by a trusted certificate authority.<br/>
+     * This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
+     * This field MAY be omitted if the node does not support gRPC-Web access.<br/>
+     * This field MUST be updated if the gRPC-Web endpoint changes.<br/>
+     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+     */
+    proto.ServiceEndpoint grpc_proxy_endpoint = 10;
 }

--- a/services/response_code.proto
+++ b/services/response_code.proto
@@ -1758,4 +1758,21 @@ enum ResponseCodeEnum {
      * The network just started at genesis and is creating system entities.
      */
     CREATING_SYSTEM_ENTITIES = 396;
+
+    /**
+     * The least common multiple of the throttle group's milliOpsPerSec is
+     * too large and it's overflowing.
+     */
+    THROTTLE_GROUP_LCM_OVERFLOW = 397;
+
+    /**
+     * Token airdrop transactions can not contain multiple senders for a single token.
+     */
+    AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN = 398;
+
+    /**
+     * The GRPC proxy endpoint is set in the NodeCreate or NodeUpdate transaction,
+     * which the network does not support.
+     */
+    GRPC_WEB_PROXY_NOT_SUPPORTED = 399;
 }

--- a/services/state/addressbook/node.proto
+++ b/services/state/addressbook/node.proto
@@ -160,4 +160,17 @@ message Node {
      * distributed at the end of the staking period.
      */
     bool decline_reward = 11;
+
+    /**
+     * A web proxy for gRPC from non-gRPC clients.
+     * <p>
+     * This endpoint SHALL be a Fully Qualified Domain Name (FQDN) using the HTTPS
+     * protocol, and SHALL support gRPC-Web for use by browser-based clients.<br/>
+     * This endpoint MUST be signed by a trusted certificate authority.<br/>
+     * This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
+     * This field MAY be omitted if the node does not support gRPC-Web access.<br/>
+     * This field MUST be updated if the gRPC-Web endpoint changes.<br/>
+     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+     */
+    proto.ServiceEndpoint grpc_proxy_endpoint = 12;
 }


### PR DESCRIPTION
**Description**:
This PR syncs the protobufs from hiero-consensus-node v0.62.2 to hedera-protobufs.

### Block Stream
* Added a `oneof verification_reference` field to the `BlockProof` message, allowing for either a `scheme_id` or `verification_key` to be specified for signature verification. (`block/stream/block_proof.proto`)
* Introduced the `ParentEventReference` message and updated the `EventHeader` message to use a `repeated ParentEventReference parents` field for referencing parent events. (`block/stream/input/event_metadata.proto`)
* Updated the `BlockHeader` message to replace `first_transaction_consensus_time` with a more detailed `block_timestamp` field, specifying rules for determining the block timestamp. (`block/stream/output/block_header.proto`)

### Deprecation
* Marked the `parents` field in the `EventCore` message as deprecated and began migrating it to the `GossipEvent` message. (`platform/event/event_core.proto`, `platform/event/gossip_event.proto`)

### Support for gRPC-Web
* Added a `grpc_proxy_endpoint` field to the `NodeCreateTransactionBody`, `NodeUpdateTransactionBody`, and `Node` messages to support gRPC-Web access via a secure proxy endpoint. (`services/node_create.proto`, `services/node_update.proto`, `services/state/addressbook/node.proto`)

### New Enumerations and Response Codes
* Added new response codes to `ResponseCodeEnum`, including `THROTTLE_GROUP_LCM_OVERFLOW`, `AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN`, and `GRPC_WEB_PROXY_NOT_SUPPORTED`. (`services/response_code.proto`)
* Added `SUBMIT_MESSAGE_WITH_CUSTOM_FEES` to the `SubType` enum to account for transactions involving custom fees. (`services/basic_types.proto`)

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
